### PR TITLE
Twitter-block and Announcements-block Plugin updates 

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -2938,6 +2938,36 @@
 			<certification type="reviewed"/>
 			<description>Added a message to remind administrators to make an appropriate entry in the cookie policy.</description>
 		</release>
+		<release date="2020-08-31" version="1.0.0.2" md5="7f176fc4d224c6e0abbc73d000786725">
+			<package>https://github.com/RBoelter/twitterBlock/releases/download/v1_0_0-2/twitterBlock-v1_0_0-2.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.1.2.4</version>
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Compatibility checks for OPM 3.2 and OPS 3.2 added, Spanish translation added, minor fixes</description>
+		</release>
 	</plugin>
 	<plugin category="blocks" product="announcementsBlock">
 		<name locale="en_US">Announcements Block</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -2991,6 +2991,36 @@
 			<certification type="reviewed"/>
 			<description>Initial release</description>
 		</release>
+		<release date="2020-08-31" version="1.0.0.1" md5="1ff62ad750333ffdbb0db358e8a4a6f1">
+			<package>https://github.com/RBoelter/announcementsBlock/releases/download/v1_0_0-1/announcementsBlock-v1_0_0-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.1.2.4</version>
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Arabic translation added and minor fixes</description>
+		</release>
 	</plugin>
 	<plugin category="gateways" product="swordServer">
 		<name locale="en_US">Sword Server Plugin</name>


### PR DESCRIPTION
Twitter-block:
- Spanish translation added
- Cypress tests added (de-/activate plugin, save settings, activate block, check block content on index page)
- .travis.yml added (compatibly tests for OJS 3.2.1, OMP 3.2.1, OPS 3.2.1)
- minor fixes
- build status: https://travis-ci.org/github/RBoelter/twitterBlock/builds/722696689

Announcement-block:
- Arabic translation added
- Cypress tests added (de-/activate plugin, save settings, activate block, write announcement, check block content on index page)
- .travis.yml added (compatibly tests for OJS 3.2.1, OMP 3.2.1, OPS 3.2.1)
- minor fixes
- build status: https://travis-ci.org/github/RBoelter/announcementsBlock/builds/722699336