### PR TITLE
Certify Plum Analytics with OJS 3.2

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -2548,8 +2548,8 @@
 			<institution>University of Pittsburgh</institution>
 			<email>uls-systemsdevelopment@pitt.edu</email>
 		</maintainer>
-		<release date="2020-07-03" version="1.3.0.1" md5="ba720f0e04a79c7e379623a506e0454d">
-			<package>https://github.com/ulsdevteam/ojs-plum-plugin/releases/download/v1.3.0-1/plumAnalytics-1.3.0.1.tar.gz</package>
+		<release date="2019-04-22" version="1.3.0.0" md5="05030eac0d4b7daa14b26febbf4b5571">
+			<package>https://github.com/ulsdevteam/ojs-plum-plugin/releases/download/v1.3.0-0/plumAnalytics-1.3.0.0.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.1.1.4</version>
 				<version>3.1.2.0</version>
@@ -2560,6 +2560,25 @@
 			</compatibility>
 			<certification type="partner" />
 			<description>Release of the Plum Analytics plugin for OJS 3.1.1/3.1.2.</description>
+		</release>
+		<release date="2020-07-03" version="1.3.0.1" md5="ba720f0e04a79c7e379623a506e0454d">
+			<package>https://github.com/ulsdevteam/ojs-plum-plugin/releases/download/v1.3.0-1/plumAnalytics-1.3.0.1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.1.1.4</version>
+				<version>3.1.2.0</version>
+				<version>3.1.2.1</version>
+				<version>3.1.2.2</version>
+				<version>3.1.2.3</version>
+				<version>3.1.2.4</version>
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<certification type="partner" />
+			<description>Release of the Plum Analytics plugin for OJS 3.1/3.2.</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="sushiLite">


### PR DESCRIPTION
Also reverts #4 to keep legacy version 1.3.0-0.