### PR TITLE
new Scopus/Crossref Citations Plugin

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -3004,7 +3004,7 @@
 		<description locale="en_US"><![CDATA[<p>This plugin makes it easy to show the latest announcements in the sidebar. It allows you to specify how many announcements are displayed.</p><p>Check the "how to use" guide on <a href="https://github.com/RBoelter/announcementsBlock">GitHub</a></p>]]></description>
 		<maintainer>
 			<name>Ronny Bölter</name>
-			<institution>Leibniz Institute for Psychology Information, Trier, Germany</institution>
+			<institution>Leibniz Institute for Psychology (ZPID), Trier, Germany</institution>
 			<email>rb@leibniz-psychology.org</email>
 		</maintainer>
 		<release date="2020-03-10" version="1.0.0.0" md5="53755e1c4bdc82bcc56884ba7448e4a4">
@@ -3018,6 +3018,43 @@
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Initial release</description>
+		</release>
+		<release date="2020-11-13" version="1.0.0.2" md5="eeb08824033b1b51416c8006522357dc">
+			<package>https://github.com/RBoelter/announcementsBlock/releases/download/v1_0_0-2/announcementsBlock-v1_0_0-2.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.1.2.4</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Settings for text alignment added</description>
+		</release>
+		<release date="2020-11-13" version="3.2.0.1" md5="f8ff333b6d35073b083a752aff3c89a1">
+			<package>https://github.com/RBoelter/announcementsBlock/releases/download/v3_2_0-1/announcementsBlock-v3_2_0-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Settings for text alignment added</description>
 		</release>
 	</plugin>
 	<plugin category="gateways" product="swordServer">

--- a/plugins.xml
+++ b/plugins.xml
@@ -2959,6 +2959,43 @@
 			<certification type="reviewed"/>
 			<description>Added a message to remind administrators to make an appropriate entry in the cookie policy.</description>
 		</release>
+		<release date="2020-11-11" version="1.0.0.3" md5="a4f5abe12d3117388c0dc07056315ff9">
+			<package>https://github.com/RBoelter/twitterBlock/releases/download/v1_0_0-3/twitterBlock-v1_0_0-3.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.1.2.4</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Spanish translation added</description>
+		</release>
+		<release date="2020-11-11" version="3.2.0.1" md5="7b5c445b7301f66329c5748cd91586fe">
+			<package>https://github.com/RBoelter/twitterBlock/releases/download/v3_2_0-1/twitterBlock-v3_2_0-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Spanish translation added</description>
+		</release>
 	</plugin>
 	<plugin category="blocks" product="announcementsBlock">
 		<name locale="en_US">Announcements Block</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -3212,4 +3212,40 @@
 			<description>PKP|PN for OJS 3.2.1-x.</description>
 		</release>
 	</plugin>
+	<plugin category="generic" product="citations">
+		<name locale="en_US">Scopus/Crossref Citations Plugin</name>
+		<homepage>https://github.com/RBoelter/citations</homepage>
+		<summary locale="en_US">Shows the total number of citations and a "cited by" article list from Scopus and/or Crossref.</summary>
+		<description locale="en_US"><![CDATA[<p>This plugin uses the DOI of an article to get all citations from Scopus and/or Crossref. Google Scholar and PubMed are also supported. The count and list of citations is displayed in the sidebar of the article details. It is possible to choose between the different providers and display only the amount of results if the list is not desired.</p> <p>For more information check <a href="https://github.com/RBoelter/citations">GitHub</a></p>]]></description>
+		<maintainer>
+			<name>Ronny Bölter</name>
+			<institution>Leibniz Institute for Psychology (ZPID), Trier, Germany</institution>
+			<email>rb@leibniz-psychology.org</email>
+		</maintainer>
+		<release date="2020-11-10" version="3.1.0.1" md5="c5f0a8552057774782ff8dee9e1abd90">
+			<package>https://github.com/RBoelter/citations/releases/download/v3_1_0-1/citations-v3_1_0-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.1.2.0</version>
+				<version>3.1.2.1</version>
+				<version>3.1.2.2</version>
+				<version>3.1.2.3</version>
+				<version>3.1.2.4</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Scopus/Crossref Citations Plugin for OJS 3.1.2-x.</description>
+		</release>
+		<release date="2020-11-10" version="3.2.0.1" md5="581988e8032cb278240ef3ea4f15e9ba">
+			<package>https://github.com/RBoelter/citations/releases/download/v3_2_0-1/citations-v3_2_0-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Scopus/Crossref Citations Plugin for OJS 3.2.0-x.</description>
+		</release>
+	</plugin>
 </plugins>


### PR DESCRIPTION
We have been using this plugin for a while in all our journals (OJS 3.1.2.4), see https://ejop.psychopen.eu/index.php/ejop/article/view/1191 -> citations tab. The plugin calls its handler via JavaScript, to keep page load as fast as possible, because the handler loads the citation details via several APIs. At the moment we upgrade all our Plugins to 3.2 because we are planning to migrate to OJS 3.2. Therefore, I have updated and tested this plugin for 3.2. Our editors and users love to have the citation information besides the article, so it could be a good plugin for many OJS journals ;-)