### PR TITLE
New Keyword Cloud version - 1.1.0.3

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -1583,6 +1583,22 @@
 			<certification type="reviewed"/>
 			<description>OJS 3.2.0-x and OJS 3.2.1 compatible version. Changes in the JS libraries used.</description>
 		</release>
+		<release date="2021-01-07" version="1.1.0.3" md5="a5454a8d53fbb59ae90c6b0cabfdaea4">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v1.1.0.3/keywordCloud-1.1.0.3.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>OJS 3.2.0-x and OJS 3.2.1 compatible version. Changes in the size of keywords and corrections in the layout code</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="bootstrap3">
 		<name locale="en_US">Bootstrap3</name>


### PR DESCRIPTION
We are releasing a new version of the Keyword Cloud plugin. It contains corrections in the size of the keywords and in the cloud layout.

Signed-off-by: Jhon <jhon@lepidus.com.br>