### PR TITLE
New version of Keyword Cloud Plugin - 1.1.0.4

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -1618,6 +1618,22 @@
 			<certification type="reviewed"/>
 			<description>OJS 3.2.0-x and OJS 3.2.1 compatible version. Changes in the JS libraries used.</description>
 		</release>
+		<release date="2021-01-28" version="1.1.0.4" md5="f76728af417142b73c5d7f3366a64096">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v1.1.0.4/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>OJS 3.2.0-x and OJS 3.2.1 compatible version. Fix bug that prevented the keywords to be displayed in the selected language and adds the Swedish language</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="bootstrap3">
 		<name locale="en_US">Bootstrap3</name>


### PR DESCRIPTION
This version adds the following changes:
* Fix the bug that prevented the keywords to be displayed in the selected language
* Adds the Swedish language to the plugin

Signed-off-by: Andrey <andrey@lepidus.com.br>
Signed-off-by: Jhon <jhon@lepidus.com.br>