### PR TITLE
Release Advanced Search plugin for OJS 3.2.x/3.3.0

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -3858,7 +3858,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<institution>Public Knowledge Project</institution>
 			<email>jason.nugent@gmail.com</email>
 		</maintainer>
-		<release date="2021-02-01" version="1.0.0.0" md5="afc381d5ca06b460222372daaf81016d">
+		<release date="2021-02-02" version="1.0.0.0" md5="417c92c4a70c47f5c8723311b2cfff76">
 			<package>https://github.com/jnugent/advancedSearch/releases/download/v1.0.0.0/advancedSearch-1.0.0.0.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.2.1.0</version>

--- a/plugins.xml
+++ b/plugins.xml
@@ -3848,4 +3848,28 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description>mEDRA plugin for OJS 3.3.0-x</description>
 		</release>
 	</plugin>
+	<plugin category="generic" product="advancedSearch">
+		<name locale="en_US">Advanced Search Filters Plugin</name>
+		<homepage>https://github.com/jnugent/advancedSearch/</homepage>
+		<summary locale="en_US">OJS 3 Plugin for adding additional search filters to the search page.</summary>
+		<description locale="en_US"><![CDATA[<p>This plugin adds back many of the search filters that were present in OJS2, including title, abstract, keywords, and index term fields.</p>]]></description>
+		<maintainer>
+			<name>Jason Nugent</name>
+			<institution>Public Knowledge Project</institution>
+			<email>jason.nugent@gmail.com</email>
+		</maintainer>
+		<release date="2021-02-01" version="1.0.0.0" md5="afc381d5ca06b460222372daaf81016d">
+			<package>https://github.com/jnugent/advancedSearch/releases/download/v1.0.0.0/advancedSearch-1.0.0.0.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+			</compatibility>
+			<certification type="partner"/>
+			<description>Initial release</description>
+		</release>
+	</plugin>
 </plugins>


### PR DESCRIPTION
Initial release of the Advanced Search plugin, which adds filters to the search form to bring back some of the fields present in OJS2. 