### PR TITLE
Citations Plugin updated

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -4160,6 +4160,32 @@
 			<certification type="reviewed"/>
 			<description>Release for OJS 3.2 and 3.3. Fixes a minor bug that occurred on an empty API response.</description>
 		</release>
+		<release date="2021-02-16" version="3.2.0.3" md5="92a105238b65b7c8ba509c0b8a9750de">
+			<package>https://github.com/RBoelter/citations/releases/download/v3_2_0-3/citations-v3_2_0-3.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Spanish translation added.</description>
+		</release>
+		<release date="2021-02-16" version="3.3.0.1" md5="fa7bfd78b49404e1a9b2126e23c54244">
+			<package>https://github.com/RBoelter/citations/releases/download/v3_3_0-1/citations-v3_3_0-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Spanish translation added and curl replaced with Guzzle</description>
+		</release>
 	</plugin>
 	<plugin category="importexport" product="portico">
 		<name locale="en_US">Portico Plugin</name>


### PR DESCRIPTION
Spanish translation added.
Because of the Guzzle support I had to split the plugin into an OJS 3.2.x and OJS 3.3.x version. 