### PR TITLE
Releasing new version of Keyword Cloud Plugin adding compatibility with OJS 3.3

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -1650,6 +1650,7 @@
 				<version>3.3.0.1</version>
 				<version>3.3.0.2</version>
 				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>OJS 3.2.0, OJS 3.2.1 and OJS 3.3.0 compatible version.</description>

--- a/plugins.xml
+++ b/plugins.xml
@@ -1634,6 +1634,23 @@
 			<certification type="reviewed"/>
 			<description>OJS 3.2.0-x and OJS 3.2.1 compatible version. Fix bug that prevented the keywords to be displayed in the selected language and adds the Swedish language</description>
 		</release>
+		<release date="2021-03-05" version="1.1.0.5" md5="a75d461583ca6e771067003a1792de6c">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v1.1.0.5/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.3.0.3</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>OJS 3.2.0, OJS 3.2.1 and OJS 3.3.0 compatible version.</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="bootstrap3">
 		<name locale="en_US">Bootstrap3</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -1646,6 +1646,9 @@
 				<version>3.2.1.2</version>
 				<version>3.2.1.3</version>
 				<version>3.2.1.4</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
 				<version>3.3.0.3</version>
 			</compatibility>
 			<certification type="reviewed"/>


### PR DESCRIPTION
We are releasing a new version of the Keyword Cloud plugin that adds compatibility with OJS 3.3

Signed-off-by: Thiago <thiago@lepidus.com.br>
Signed-off-by: Hilton <hilton@lepidus.com.br>