### PR TITLE
Releasing new version of Keyword Cloud Plugin to fix unexpected change in relation to the first versions

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -1634,6 +1634,29 @@
 			<certification type="reviewed"/>
 			<description>OJS 3.2.0-x and OJS 3.2.1 compatible version. Fix bug that prevented the keywords to be displayed in the selected language and adds the Swedish language</description>
 		</release>
+		<release date="2021-05-05" version="1.1.0.5" md5="cd3e9db75368283a2abb185d11d52e4a">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v1.1.0.5/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>OJS 3.2.x and OJS 3.3.0-x compatible version. Resize the plugin area, changes the font family to serif and add opacity and font size variation to the keywords.</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="bootstrap3">
 		<name locale="en_US">Bootstrap3</name>


### PR DESCRIPTION
We are releasing a new version of the Keyword Cloud plugin to correct unexpected behavior changes compared to the first versions. This release resizes the keyword cloud area and adds opacity and font size variation to the keywords in it.