### PR TITLE
Fix description locale tag of Authors History Plugin

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -886,7 +886,7 @@
 		<summary locale="pt_BR">Este plugin adiciona uma aba na visualização da submissão, onde todos as submissões de cada contribuidor são listadas.</summary>
 		<description locale="en_US"><![CDATA[<p>This plugin adds a tab in the submission view, where all submissions from each contributor are listed.</p>]]></description>
 		<description locale="es_ES"><![CDATA[<p>Este complemento agrega una pestaña en la vista de envío, donde se enumeran todos los envíos de cada colaborador.</p>]]></description>
-		<description locale="es_ES"><![CDATA[<p>Este plugin adiciona uma guia na visualização da submissão, onde todos as submissões de cada contribuidor são listadas</p>]]></description>
+		<description locale="pt_BR"><![CDATA[<p>Este plugin adiciona uma guia na visualização da submissão, onde todos as submissões de cada contribuidor são listadas</p>]]></description>
 		<maintainer>
 			<name>SciELO Brazil Online Submission and Preprints Unit</name>
 			<institution>SciELO in collaboration with Lepidus</institution>


### PR DESCRIPTION
We noticed that one of the locales for the plugin description was mistaked. This PR replaces it by the right one.