### PR TITLE
Adds first release of Plugins Update Notification to the plugin gallery

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -926,6 +926,69 @@
 			<description locale="pt_BR">Esta é a primeira versão deste plugin a ser enviada para a galeria de plugins da PKP. Sua principal funcionalidade é adicionar uma guia na visualização da submissão, onde todos as submissões de cada contribuidor são listadas.</description>
 		</release>
 	</plugin>
+	<plugin category="generic" product="pluginUpdateNotification">
+		<name locale="en_US">Plugins update notification</name>
+		<name locale="es_ES">Notificación de actualización de módulos</name>
+		<name locale="pt_BR">Notificação de atualização de plugins</name>
+		<homepage>https://github.com/lepidus/pluginUpdateNotification</homepage>
+		<summary locale="en_US">This plugin generates a notification whenever an update to a gallery plugin is available</summary>
+		<summary locale="es_ES">Este módulo genera una notificación cada vez que se encuentra disponible una actualización de un módulo de la galería</summary>
+		<summary locale="pt_BR">Este plugin gera uma notificação sempre que há uma atualização disponível de um plugin da galeria</summary>
+		<description locale="en_US"><![CDATA[<p>This plugin generates a notification in the Website Settings informing which plugins have an upgrade available at the plugin gallery</p>]]></description>
+		<description locale="es_ES"><![CDATA[<p>Este complemento genera una notificación en los Ajustes del sítio web que informa qué módulos tienen una actualización disponible en la galería de módulos</p>]]></description>
+		<description locale="pt_BR"><![CDATA[<p>Esse plugin gera uma notificação nas Configurações do Website informando quais plugins possuem uma atualização disponível através da galeria de plugins</p>]]></description>
+		<maintainer>
+			<name>SciELO Brazil Online Submission and Preprints Unit</name>
+			<institution>SciELO in collaboration with Lepidus</institution>
+			<email>scielo.submission@scielo.org</email>
+		</maintainer>
+		<release date="2021-05-19" version="1.2.0.0" md5="afc1389af66b5e0811eb4822f37cee05">
+			<package>https://github.com/lepidus/pluginUpdateNotification/releases/download/v1.2.0/pluginUpdateNotification.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">This is the first release of this plugin to be sent to PKP Plugin Gallery. Its main functionality is to add a notification in the Website Settings informing which plugins have an upgrade available.</description>
+			<description locale="es_ES">Esta es la primera versión de este módulo que se envía a la Galería de módulos de PKP. Su principal funcionalidad es agregar una notificación en los Ajustes del sítio web informando qué módulos tienen una actualización disponible.</description>
+			<description locale="pt_BR">Esta é a primeira versão deste plugin a ser enviada à Galeria de Plugins da PKP. Sua principal funcionalidade é adicionar uma notificação nas Configurações do Website, informando quais plugins possuem uma atualização disponível.</description>
+		</release>
+	</plugin>
 	<plugin category="generic" product="piwik">
 		<name locale="en_US">Matomo</name>
 		<homepage>https://github.com/pkp/piwik</homepage>


### PR DESCRIPTION
This plugin adds a notification in Website Settings informing which plugins have an upgrade available at the plugin gallery. It's useful for the admins, since they don't need to access the Plugin Gallery tab directly to know which plugins are upgradeable.

It has been used in the SciELO Preprints server, but can be used in other contexts too.