### PR TITLE
Add 2 releases for publons plugin

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -4707,6 +4707,35 @@
 			<institution>Publons</institution>
 			<email>ojs@publons.com</email>
 		</maintainer>
+		<release date="2021-06-01" version="2021.6.1.0" md5="a19303dfd77fbd0dc790b5f92e922f2c">
+			<package>https://github.com/publons/ojs_3_plugin/releases/download/2021.6.1.0/publons.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+			</compatibility>
+			<certification type="partner"/>
+			<description>Fix compatibility issues with OJS v3.3. Fixed the send reviews button for already sent reviews.</description>
+		</release>
+		<release date="2020-06-05" version="2020.6.5.0" md5="71d1dbed08050f4eb589927f02d8e4ab">
+			<package>https://github.com/publons/ojs_3_plugin/releases/download/2020.6.5.0/publons.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+			</compatibility>
+			<certification type="partner"/>
+			<description>Fix compatibility issues with OJS v3.2.0. Reset versioning to use calendar versioning.</description>
+		</release>
 		<release date="2019-10-25" version="3.2.2.0" md5="2f8bc414e9694002adde559844448b80">
 			<package>https://github.com/publons/ojs_3/releases/download/3.2.2.0/publons.tar.gz</package>
 			<compatibility application="ojs2">


### PR DESCRIPTION
Adds 2 most recent releases of the Publons plugin to the gallery. This covers 3.2 and 3.3 versions of OJS.