### PR TITLE
Add first release of the Public Identifier Resolver plugin

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -5383,8 +5383,8 @@
 			<institution>Universidad La Salle</institution>
 			<email>yasielpv@gmail.com</email>
 		</maintainer>
-		<release date="2021-10-15" version="1.0.1.0" md5="d24109f9fb868b7252cb6f52ce96b0c0">
-			<package>https://github.com/yasielpv/pubIdResolver/releases/download/v1_0_1-0/pubIdResolver-v1_0_1-0.tar.gz</package>
+		<release date="2021-11-19" version="1.0.2.0" md5="e503d4323e8eca75c0063d3872ff6d62">
+			<package>https://github.com/yasielpv/pubIdResolver/releases/download/v1_0_2-0/pubIdResolver-v1_0_2-0.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.1.2.0</version>
 				<version>3.1.2.1</version>

--- a/plugins.xml
+++ b/plugins.xml
@@ -5373,6 +5373,47 @@
 			<description>Maintenance release for OJS 3.2.1</description>
 		</release>
 	</plugin>
+	<plugin category="gateways" product="pubIdResolver">
+		<name locale="en_US">Public Identifier Resolver</name>
+		<homepage>https://github.com/yasielpv/pubIdResolver</homepage>
+		<summary locale="en_US">Allows resolving the URL of an issue, article and galley from your public identifier registered in OJS.</summary>
+		<description locale="en_US"><![CDATA[<p>The Public Identifier Resolver plugin resolves individual articles, issues and galleys in the current OJS installation using the supplied public identifier register in OJS. The public identifier can be DOI, URN, ARK, PURL, etc. Also, It can obtain the element metadata using the format ERC adding question marks at the end of the persistent identifier. ERC format includes the metadata who, what, when, where, how and target.</p>]]></description>
+		<maintainer>
+			<name>Yasiel Perez Vera</name>
+			<institution>Universidad La Salle</institution>
+			<email>yasielpv@gmail.com</email>
+		</maintainer>
+		<release date="2021-10-15" version="1.0.1.0" md5="d24109f9fb868b7252cb6f52ce96b0c0">
+			<package>https://github.com/yasielpv/pubIdResolver/releases/download/v1_0_1-0/pubIdResolver-v1_0_1-0.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.1.2.0</version>
+				<version>3.1.2.1</version>
+				<version>3.1.2.2</version>
+				<version>3.1.2.3</version>
+				<version>3.1.2.4</version>
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Initial release</description>
+		</release>
+	</plugin>
 	<plugin category="generic" product="returningAuthorScreening">
 		<name locale="en_US">Returning Author Screening Plugin</name>
 		<homepage>https://github.com/pkp/returningAuthorScreening</homepage>


### PR DESCRIPTION
Hi @asmecher, This is a plugin to resolve the individual URL of articles, issues and galleys in the OJS installation using the supplied public identifier registered in OJS. It can be addressed at the following URL pattern:

`http://localhost/index.php/myJournal/gateway/plugin/pubIdResolver/[pubId]`

where, of course, localhost is the local server name, and myJournal is the path to a particular journal.

The resolver accepts parameters after the given URL pattern in the following formats:

http://.../[doi]
http://.../[urn]
http://.../[purl]
http://.../[ark]

...where [doi], [urn], [purl], and [ark] are string identifying the public identifier of the desired content. For example:

ARK:
`http://localhost/index.php/myJournal/gateway/plugin/pubIdResolver/ark:/12345/fk12345`

DOI:
`http://localhost/index.php/myJournal/gateway/plugin/pubIdResolver/10.12345/fk12345`

Also, It can obtain the element metadata using the format ERC adding question marks at the end of the persistent identifier. ERC format includes the metadata who, what, when, where, how and target. Who is the creator of the item,  What is the name of the item, When is the publication date of the item, Where is the persistent URL of the item, How is the format of the item and Target is the final URL of the item. For example:

`http://localhost/index.php/myJournal/gateway/plugin/pubIdResolver/ark:/12345/fk12345?`

obtaining this response:

> erc:  
> who: LAST NAME AUTHOR 1, FIRST NAME AUTHOR 1; LAST NAME AUTHOR 2, FIRST NAME AUTHOR 2
> what: TITLE
> when: DATE
> where: ark:/12345/fk12345 (https://n2t.net/ark:/12345/fk12345)
> how: (:mtype text) article
> _t: http://localhost/index.php/myJournal/article/view/45
