### PR TITLE
Fix md5sum of Plaudit v1.0.3

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -8088,7 +8088,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="es_ES">Esta versión agrega compatibilidad con OJS y OMP en las versiones 3.3.0-x.</description>
 			<description locale="pt_BR">Esta versão adiciona suporte para o OJS e OMP nas versões 3.3.0-x.</description>
 		</release>
-		<release date="2022-08-24" version="1.0.3.0" md5="6dcf36db86be9d335a198bf39eab9699">
+		<release date="2022-08-24" version="1.0.3.0" md5="ada945224cf8cb5db0b03cb91621d474">
 			<package>https://github.com/lepidus/plaudit/releases/download/v1.0.3/plaudit.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.3.0.0</version>


### PR DESCRIPTION
In previous PR #159, the `md5` indicated for the package of the `v1.0.3` release was incorrect.

This makes it impossible to install the Plugin via the plugin gallery, raising the **"Incorrect MD5 checksum!"** alert.

This PR fixes the expected `md5` field