### PR TITLE
Texture Plugin 2.4.3.9

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -3544,6 +3544,25 @@
 			<certification type="official"/>
 			<description>This release updates texture plugin compatible with OJS 3.3.0.0 and after versions </description>
 		</release>
+		<release date="2021-09-13" version="2.4.3.9" md5="b9f9ab806df0e938aafcb855d65b37b9">
+			<package>https://github.com/pkp/texture/releases/download/v2_4_3-9/texture-v2_4_3-9.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+			</compatibility>
+			<certification type="official"/>
+			<description><![CDATA[<p>Version 2.4.3.9 adds following enhancements to the texture plugin for OJS 3.3</p><ul><li>Create galley from XML files for JATS XML files</li><li>By galley creation all dependent files are copied to the galley</li><li>By user selection following metadata blocks are added or updated to the jats metadata section<ul><li>Journal metadata</li><li>Publication history (recieved, accepted and published date )</li><li>published date can be either taken over or modified in the create galley modal</li><li>First page and last page of the article in a volume</li><li>Create the cc-by license block inserted in the journal. Additionally, If a ported cc-by url is added it will be mapped accordingly.</li></ul></li></ul>]]></description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="crossrefReferenceLinking">
 		<name locale="en_US">Crossref Reference Linking Plugin</name>


### PR DESCRIPTION
### Description

Version 2.4.3.9 adds following enhancements to the texture plugin for OJS 3.3

-  Create galley from XML files for JATS XML files 
- By galley creation all dependent files are copied to the galley
- By user selection following  metadata blocks are added or updated to the jats metadata section
  *   Journal metadata 
  *  Publication history  (recieved, accepted and published date )
  * published date can be either taken over or modified in the create galley modal
  * First page and last page of the article in a volume

  
```xml
<journal-meta>
 <journal-id journal-id-type="publisher-id">JPKJPK</journal-id> 
 <issn pub-type="epub">0378-5955</issn>
 <publisher>
 <publisher-name>Public Knowledge Project</publisher-name>
</publisher>
</journal-meta>
```
   
```xml
<history>
<date type="received" iso-8601-date="2022-09-07">
<day>07</day>
<month>09</month>
<year>2022</year>
</date>
<date type="accepted" iso-8601-date="2022-09-12">
<day>12</day>
<month>09</month>
<year>2022</year>
</date>
<date type="published" iso-8601-date="2022-12-11">
<day>11</day>
<month>12</month>
<year>2022</year>
</date>
</history>
```

```xml
<pub-date pub-type="epub">
<day>11</day>
<month>12</month>
<year>2022</year>
<volume>1</volume>
<fpage>1</fpage>
<lpage>2</lpage>
</pub-date>
<history>
```
*  Create the  cc-by license block inserted  in the journal. Additionally, If a ported  cc-by url is added it will be mapped accordingly.
  e.g. _https://creativecommons.org/licenses/by/3.0/de/deed.en_ will be mapped to the following block by using the counry codes in OJS.
    
```xml
<permissions>
            <copyright-statement>© 2022 The Author(s)</copyright-statement>
            <copyright-year>2022</copyright-year>
            <license license-type="open-access"
              xlink:href="https://creativecommons.org/licenses/by/3.0/de/deed.en" xml:lang="en">
              <license-p><inline-graphic
                xlink:href="http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by.svg"
              />This work is licensed under a Creative Commons Attribution 3.0 Germany License (CC BY 3.0 DE).</license-p>
            </license>
</permissions>
```

### Demo
https://user-images.githubusercontent.com/1921992/189820398-3e2693fa-2929-49a2-9e6b-4bb0bc3b5806.mp4

### Milestone
- https://github.com/pkp/texture/milestone/1


### Issues
- https://github.com/pkp/texture/issues/106
- https://github.com/pkp/texture/issues/110
- https://github.com/pkp/texture/issues/112
- https://github.com/pkp/texture/issues/113
- https://github.com/pkp/texture/issues/114

