### PR TITLE
Texture 2.4.39 the plugin texture-v2_4_3-9.tar.gz file

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -3616,7 +3616,7 @@
 			<certification type="official"/>
 			<description>This release updates texture plugin compatible with OJS 3.3.0.0 and after versions </description>
 		</release>
-		<release date="2021-09-21" version="2.4.3.9" md5="deb6097604057d2a327878cb064bfd01">
+		<release date="2021-09-21" version="2.4.3.9" md5="17b07569356e49f4498fb3e7947bf9f6">
 			<package>https://github.com/pkp/texture/releases/download/v2_4_3-9/texture-v2_4_3-9.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.3.0.0</version>


### PR DESCRIPTION
Replace the  [texture-v2_4_3-9.tar.gz](https://github.com/pkp/texture/releases/download/v2_4_3-9/texture-v2_4_3-9.tar.gz)
