### PR TITLE
Fixed directory name to match application name

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -10272,7 +10272,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="pt_BR">Campo de declaração de biografia do autor obrigatório</description>
 		</release>
 	</plugin>
-	<plugin category="themes" product="ojs-gopher-theme">
+	<plugin category="themes" product="gopher">
 		<name locale="en">Gopher Theme</name>
 		<name locale="en_US">Gopher Theme</name>
 		<homepage>https://github.com/UMNLibraries/ojs-gopher-theme</homepage>

--- a/plugins.xml
+++ b/plugins.xml
@@ -10306,6 +10306,28 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			</compatibility>
 			<description>Initial release.</description>
 		</release>
+		<release date="2023-03-31" version="1.0.0.1" md5="55a4b5d50d3bf2abb7e046c7e1832cc8">
+			<package>https://github.com/UMNLibraries/ojs-gopher-theme/releases/download/1_0_0-1/ojs-gopher-theme-1_0_0-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+			</compatibility>
+			<description locale="en">Fixed base directory name.</description>
+			<description locale="en_US">Fixed base directory name.</description>
+	</release>
 	</plugin>
 </plugins>
 

--- a/plugins.xml
+++ b/plugins.xml
@@ -10328,6 +10328,28 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="en">Fixed base directory name.</description>
 			<description locale="en_US">Fixed base directory name.</description>
 	</release>
+	<release date="2023-05-10" version="1.0.0.2" md5="3f1a2997c7781b796ed5d37934e9f750">
+			<package>https://github.com/UMNLibraries/ojs-gopher-theme/releases/download/1_0_0-2/gopher-1_0_0-2.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+			</compatibility>
+			<description locale="en">Updated version and download metadata to match.</description>
+			<description locale="en_US">Updated version and download metadata to match.</description>
+	</release>
 	</plugin>
 </plugins>
 


### PR DESCRIPTION
Application metadata name "gopher" did not match "ojs-gopher-theme". Changed to "gopher".