### PR TITLE
Version 1.0.1-0 release.

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -10700,6 +10700,28 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="en">Updated version and download metadata to match.</description>
 			<description locale="en_US">Updated version and download metadata to match.</description>
 		</release>
+		<release date="2023-06-12" version="1.0.1.0" md5="3f8cf517b51e9d648ab910e9b22a827b">
+			<package>https://github.com/UMNLibraries/ojs-gopher-theme/releases/download/1_0_1-0/gopher-1_0_1-0.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+			</compatibility>
+			<description locale="en">Design changes and bug fixes.</description>
+			<description locale="en_US">Design changes and bug fixes.</description>
+		</release>
 	</plugin>
 </plugins>
 


### PR DESCRIPTION
Three updates to the theme including pdf display fix, current issue header display on submission only sites, and removing the doi section from the sidebar.