### PR TITLE
Adds new releases of keyword cloud block plugin

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -3700,6 +3700,88 @@
 			<certification type="reviewed"/>
 			<description>OJS 3.2.x and OJS 3.3.0-x compatible version. Fix an cache-related error that occurred when calling getFileCache with no callback.</description>
 		</release>
+		<release date="2023-04-04" version="1.1.0.8" md5="452154211554cbdb9a28529319119a6f">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v1.1.0.8/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.0.4</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+				<version>3.3.0.15</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.0.4</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+				<version>3.3.0.15</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This release adds support for OMP</description>
+			<description locale="en_US">This release adds support for OMP</description>
+			<description locale="es_ES">Esta versión agrega soporte para OMP</description>
+			<description locale="pt_BR">Essa versão adiciona suporte ao OMP</description>
+		</release>
+		<release date="2023-07-17" version="2.0.0.0" md5="0f164b8f8c67c5e6e87f1811bf178b7d">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v2.0.0.0/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.4.0.0</version>
+				<version>3.4.0.1</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.4.0.0</version>
+				<version>3.4.0.1</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This release adds support for 3.4.0-x application releases</description>
+			<description locale="en_US">This release adds support for 3.4.0-x application releases</description>
+			<description locale="es_ES">Esta versión agrega soporte para las versiones de aplicaciones 3.4.0-x</description>
+			<description locale="pt_BR">Essa versão adiciona suporte às versões 3.4.0-x das aplicações</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="bootstrap3">
 		<name locale="en">Bootstrap3</name>


### PR DESCRIPTION
This PR adds a new release, with compatibility for OJS and OMP 3.4.0-x. It also adds a previous release, which added support for OMP in 3.3.0-x releases.