### PR TITLE
Adds new releases for Keyword Cloud - v1.1.1/v2.0.1

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -3833,6 +3833,84 @@
 			<description locale="es">Esta versión agrega soporte para las versiones de aplicaciones 3.4.0-x</description>
 			<description locale="pt_BR">Essa versão adiciona suporte às versões 3.4.0-x das aplicações</description>
 		</release>
+		<release date="2023-08-10" version="1.1.1.0" md5="983102495ae25b048ab537db7fe07592">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v1.1.1/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.0.4</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+				<version>3.3.0.15</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.0.4</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+				<version>3.3.0.15</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">This release normalizes keywords to lowercase and removes duplicated keywords</description>
+			<description locale="es_ES">Esta versión normaliza las palabras clave a minúsculas y elimina las palabras clave duplicadas</description>
+			<description locale="pt_BR">Essa versão normaliza as palavras-chave para minúsculo e remove palavras-chave duplicadas</description>
+		</release>
+		<release date="2023-08-10" version="2.0.1.0" md5="b752acc16ef701e5f82ef3cffe4f5aa0">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v2.0.1/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This release normalizes keywords to lowercase and removes duplicated keywords</description>
+			<description locale="es">Esta versión normaliza las palabras clave a minúsculas y elimina las palabras clave duplicadas</description>
+			<description locale="pt_BR">Essa versão normaliza as palavras-chave para minúsculo e remove palavras-chave duplicadas</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="bootstrap3">
 		<name locale="en">Bootstrap3</name>


### PR DESCRIPTION
This PR adds a new releases of the plugin Keyword Cloud, normalizing keywords to lowercase and removing duplicates.