### PR TITLE
Assert forward compatibility for 3.3.0.x

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -205,7 +205,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -224,7 +224,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Release of the Hypothes.is plugin for OJS/OPS 3.3.</description>
@@ -309,7 +309,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.0.0</version>
@@ -339,7 +339,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.0.0</version>
@@ -369,7 +369,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Release of the Shibboleth plugin for 3.2 and later.</description>
@@ -404,7 +404,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.0.0</version>
@@ -434,7 +434,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.0.0</version>
@@ -464,7 +464,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Release of the Shibboleth plugin for 3.2 and later.</description>
@@ -712,7 +712,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -731,7 +731,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -750,7 +750,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Adds new translations to the previous release.</description>
@@ -870,7 +870,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -889,7 +889,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Release of the iThenticate plugin for OJS/OMP 3.3.0.</description>
@@ -913,7 +913,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -932,7 +932,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Adds new translations and bug fixes.</description>
@@ -956,7 +956,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -975,7 +975,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Fix missing dependency in release version.</description>
@@ -999,7 +999,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -1018,7 +1018,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Various bugfixes around error handling.</description>
@@ -1100,7 +1100,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Release 1.0.3-2 of the COinS plugin for OJS 3.2.1/3.3.0.</description>
@@ -1130,7 +1130,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Release 1.0.3-3 of the COinS plugin for OJS 3.2.1/3.3.0.</description>
@@ -1322,7 +1322,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release of the QuickSubmit plugin for OJS 3.3.0.</description>
@@ -1346,7 +1346,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release of the QuickSubmit plugin for OJS 3.3.0.</description>
@@ -1458,7 +1458,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -1478,7 +1478,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -1498,7 +1498,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Update for compatibility with v3.3.0</description>
@@ -1549,7 +1549,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -1575,7 +1575,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This is the first release of this plugin to be sent to PKP Plugin Gallery. Its main functionality is to add a tab in the submission view where all submission from each contributor are listed.</description>
@@ -1609,7 +1609,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -1635,7 +1635,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This release fixes a bug that occurred when deleting one of the previous submissions from one of the submission's authors</description>
@@ -1669,7 +1669,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -1695,7 +1695,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">Improves plugin's performance and adds checking for cases in which different authors use the same email.</description>
@@ -1729,7 +1729,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -1755,7 +1755,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This release adds translation support for Russian language.</description>
@@ -1789,7 +1789,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -1815,7 +1815,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This release fixes the link for published articles exhibited in authors history.</description>
@@ -1869,7 +1869,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -1895,7 +1895,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -1921,7 +1921,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This is the first release of this plugin to be sent to PKP Plugin Gallery. Its main functionality is to add a notification in the Website Settings informing which plugins have an upgrade available.</description>
@@ -2001,7 +2001,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This is the first release of this plugin to be sent to PKP Plugin Gallery.</description>
@@ -2159,7 +2159,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -2178,7 +2178,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Piwik release for OJS/OMP 3.3.0</description>
@@ -2249,7 +2249,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.8</version>
@@ -2261,7 +2261,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/><description>Release of the Shariff plugin for OJS 3.3.0.</description>
 		</release>
@@ -2277,7 +2277,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.8</version>
@@ -2289,7 +2289,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/><description>This release of the Shariff plugin for OJS/OMP 3.3.0 fixes a compatibility issue with PHP 8.</description>
 		</release>
@@ -2318,7 +2318,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.8</version>
@@ -2330,7 +2330,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/><description>This release of the Shariff plugin for OJS/OMP/OPS 3.3.0 WCAG compliant button styles.</description>
 		</release>
@@ -2516,7 +2516,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -2535,7 +2535,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -2554,7 +2554,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>AddThis for OJS/OMP/OPS 3.3.0.</description>
@@ -2703,7 +2703,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release of the SubscriptionSSO plugin for OJS 3.3.x.</description>
@@ -2728,7 +2728,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release of the SubscriptionSSO plugin for OJS 3.3.x.</description>
@@ -2814,7 +2814,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -2833,7 +2833,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Update for compatibility with v3.3.</description>
@@ -2871,7 +2871,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -2890,7 +2890,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -2909,7 +2909,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>This release adds support for OPS 3.3.0. It also adds translation for Brazilian Portuguese</description>
@@ -3048,7 +3048,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -3067,7 +3067,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -3086,7 +3086,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Release of the custom headers plugin for OJS/OMP/OPS 3.3.0.</description>
@@ -3110,7 +3110,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -3129,7 +3129,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -3148,7 +3148,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release of the custom header plugin for OJS/OMP/OPS 3.3.0.</description>
@@ -3172,7 +3172,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -3191,7 +3191,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -3210,7 +3210,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release of the custom header plugin for OJS/OMP/OPS 3.3.0.</description>
@@ -3324,7 +3324,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -3350,7 +3350,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -3376,7 +3376,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>A minor update that standardizes a couple of language definitions.</description>
@@ -3401,7 +3401,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -3421,7 +3421,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -3441,7 +3441,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Add ability to select other languages than English from the search form.</description>
@@ -3651,7 +3651,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Compatibility release of the JATS Template plugin for OJS 3.3.0</description>
@@ -3675,7 +3675,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Compatibility release of the JATS Template plugin for OJS 3.3.0</description>
@@ -3699,7 +3699,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Compatibility release of the JATS Template plugin for OJS 3.3.0</description>
@@ -3965,7 +3965,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Compatibility release of the OAI JATS plugin for OJS 3.3</description>
@@ -3989,7 +3989,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Bugfix release of the OAI JATS plugin for OJS 3.3</description>
@@ -4013,7 +4013,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Bugfix release of the OAI JATS plugin for OJS 3.3</description>
@@ -4037,7 +4037,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Bugfix release of the OAI JATS plugin for OJS 3.3</description>
@@ -4174,7 +4174,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>OJS 3.2.x and OJS 3.3.0-x compatible version. Resize the plugin area, changes the font family to serif and add opacity and font size variation to the keywords.</description>
@@ -4210,7 +4210,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>OJS 3.2.x and OJS 3.3.0-x compatible version. Fix an cache-related error that occurred when calling getFileCache with no callback.</description>
@@ -4246,7 +4246,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.0.0</version>
@@ -4277,7 +4277,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en_US">This release adds support for OMP</description>
@@ -4328,7 +4328,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.0.0</version>
@@ -4359,7 +4359,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en_US">This release normalizes keywords to lowercase and removes duplicated keywords</description>
@@ -4533,7 +4533,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This release updates the theme to be compatible with OJS 3.3.</description>
@@ -4558,7 +4558,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This is a minor release to remove the .git directory from the release package. No other files were modified.</description>
@@ -4583,7 +4583,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This is a minor release to improve PHP8.1 compatibility.</description>
@@ -4718,7 +4718,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>This release updates a theme to be compatible with OJS 3.3.0.1, fixes display of multilingual keywords on article landing page as well as displays article's license terms, and adds section policies on a submission page</description>
@@ -4742,7 +4742,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Adds compatibility with PHP 8.1</description>
@@ -4891,7 +4891,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>This release updates a theme to be compatible with OJS 3.3.0.1, fixes display of multilingual keywords on article landing page as well as displays article's license terms, and adds section policies on a submission page</description>
@@ -4915,7 +4915,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Adds compatibility with PHP 8.1</description>
@@ -5020,7 +5020,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>A minor update to support changes to the default theme in OJS 3.3.</description>
@@ -5060,7 +5060,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>Initial release.</description>
@@ -5085,7 +5085,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>A minor update to support the material theme in OJS 3.3.0 with bugfixes.</description>
@@ -5110,7 +5110,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>Restyled Material 2.0.0 theme for OJS 3.3.0 with bugfixes.</description>
@@ -5135,7 +5135,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>This release upgrades Material plugin to version 2.0.1-0</description>
@@ -5160,7 +5160,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>Material plugin (version 2.1.1-0), includes localization extension.</description>
@@ -5364,7 +5364,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>This release updates texture plugin compatible with OJS 3.3.0.0 and after versions </description>
@@ -5389,7 +5389,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description><![CDATA[<p>Version 2.4.3.9 adds following enhancements to the texture plugin for OJS 3.3</p><ul><li>Create galley from XML files for JATS XML files</li><li>By galley creation all dependent files are copied to the galley</li><li>By user selection following metadata blocks are added or updated to the jats metadata section<ul><li>Journal metadata</li><li>Publication history (recieved, accepted and published date )</li><li>published date can be either taken over or modified in the create galley modal</li><li>First page and last page of the article in a volume</li><li>Create the cc-by license block inserted in the journal. Additionally, If a ported cc-by url is added it will be mapped accordingly.</li></ul></li></ul>]]></description>
@@ -5450,7 +5450,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release of the plugin for OJS 3.3.0.</description>
@@ -5471,7 +5471,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Bugfix release of the plugin for OJS 3.3.0</description>
@@ -5611,7 +5611,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>This release updates a theme to be compatible with OJS 3.3.0.1 and fixes minor bugs</description>
@@ -5635,7 +5635,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Adds compatibility with PHP 8.1</description>
@@ -5954,7 +5954,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -5974,7 +5974,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Adds support for OJS/OPS 3.3, Better error hanlding for Guzzle,  Member API publication update</description>
@@ -5999,7 +5999,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6019,7 +6019,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Disable site-index mails, Client-Secret and ID validation </description>
@@ -6044,7 +6044,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6064,7 +6064,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Orcid API V3.0 support </description>
@@ -6110,7 +6110,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6130,7 +6130,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Orcid API V3.0 support - update </description>
@@ -6176,7 +6176,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6196,7 +6196,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Plugin configuration enhancement </description>
@@ -6221,7 +6221,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6241,7 +6241,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Reviewer credit support</description>
@@ -6266,7 +6266,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6286,7 +6286,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Reviewer credit support</description>
@@ -6332,7 +6332,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6352,7 +6352,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Bump version to resolve conflicts</description>
@@ -6377,7 +6377,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6397,7 +6397,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Bugfix Contributor Email</description>
@@ -6487,7 +6487,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -6507,7 +6507,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>API Error  capturing - Bugfix</description>
@@ -6868,7 +6868,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -6894,7 +6894,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -6920,7 +6920,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Maintenance release for OJS/OMP/OPS 3.2.1 / 3.3.0.</description>
@@ -6999,7 +6999,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Maintenance release for 3.3.0.</description>
@@ -7024,7 +7024,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.4</version>
@@ -7040,7 +7040,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Maintenance release for OJS/OPS 3.3.0.</description>
@@ -7209,7 +7209,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>Update for compatibility with v3.3.</description>
@@ -8623,7 +8623,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -8643,7 +8643,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/>
 			<description>Release of the authorRequirements plugin for OJS/OMP 3.3.0</description>
@@ -8668,7 +8668,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -8688,7 +8688,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/>
 			<description>Update to authorRequirements plugin fixing compatability issues in OMP 3.3</description>
@@ -8713,7 +8713,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -8733,7 +8733,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/>
 			<description>Updated for cross-application compatibility.</description>
@@ -8927,7 +8927,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -8953,7 +8953,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -8979,7 +8979,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release for OJS/OMP v3.2.1.</description>
@@ -9010,7 +9010,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -9036,7 +9036,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -9062,7 +9062,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This update adds translations for Finnish, Norwegian, Czech, Greek, and Vietnamese.</description>
@@ -9087,7 +9087,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -9107,7 +9107,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -9127,7 +9127,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This is a bugfix release for compatibility with recent PHP releases.</description>
@@ -9152,7 +9152,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -9172,7 +9172,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -9192,7 +9192,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This is a bugfix release for compatibility with recent PHP releases.</description>
@@ -9305,7 +9305,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -9331,7 +9331,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -9357,7 +9357,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release for OJS/OPS/OMP 3.2.1.</description>
@@ -9388,7 +9388,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -9414,7 +9414,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -9440,7 +9440,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This update adds translations for Arabic, Spanish and Ukrainian.</description>
@@ -9471,7 +9471,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.1.0</version>
@@ -9497,7 +9497,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.1.0</version>
@@ -9523,7 +9523,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>This update adds support for extra text editor options in the announcements form.</description>
@@ -9548,7 +9548,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -9568,7 +9568,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -9588,7 +9588,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Maintenance release.</description>
@@ -9691,7 +9691,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.0.0</version>
@@ -9721,7 +9721,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.0.0</version>
@@ -9751,7 +9751,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Spanish translation added</description>
@@ -9821,7 +9821,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.2.0.0</version>
@@ -9851,7 +9851,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.2.0.0</version>
@@ -9881,7 +9881,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Settings for text alignment added</description>
@@ -9975,7 +9975,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Initial release</description>
@@ -10080,7 +10080,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -10099,7 +10099,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -10118,7 +10118,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>OpenGraph plugin for 3.3</description>
@@ -10156,7 +10156,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/>
 			<description>Fix compatibility issues with OJS v3.3. Fixed the send reviews button for already sent reviews.</description>
@@ -10263,7 +10263,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>This release updates a theme to be compatible with OJS 3.3.0.1, fixes display of multilingual keywords on article landing page as well as displays article's license terms</description>
@@ -10287,7 +10287,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Adds compatibility with PHP 8.1</description>
@@ -10418,7 +10418,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>PKP|PN for OJS 3.3.0-x.</description>
@@ -10443,7 +10443,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>PKP|PN for OJS 3.3.0-x.</description>
@@ -10549,7 +10549,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Release for OJS 3.2 and 3.3. Fixes a minor bug that occurred on an empty API response.</description>
@@ -10591,7 +10591,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Spanish translation added and curl replaced with Guzzle</description>
@@ -10615,7 +10615,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Added Crossref contact information to request permission to use the cited-by service.</description>
@@ -10736,7 +10736,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Portico for OJS 3.3.x.</description>
@@ -10801,7 +10801,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/>
 			<description>Adds support for OJS 3.3, better handling of placeholders</description>
@@ -10831,7 +10831,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -10850,7 +10850,7 @@
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner"/>
 			<description>Adds support for OPS 3.3</description>
@@ -10922,7 +10922,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>mEDRA plugin for OJS 3.3.0-x</description>
@@ -10943,7 +10943,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Bugfix release of the plugin for OJS 3.3.0</description>
@@ -10964,7 +10964,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Bugfix release of the plugin for OJS 3.3.0</description>
@@ -10979,7 +10979,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>Collection element and unstructured citation list, for OJS 3.3.0-14</description>
@@ -10994,7 +10994,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official" />
 			<description>No contributors, subtitle element, different schema location for test and production</description>
@@ -11056,7 +11056,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>ARK plugin for OJS 3.2.x.x - 3.3.x.x</description>
@@ -11104,7 +11104,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>ARK plugin for OJS 3.2.x.x - 3.3.x.x</description>
@@ -11194,7 +11194,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -11213,7 +11213,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -11232,7 +11232,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description>OpenID plugin for OJS 3.3.0-x (first release)</description>
@@ -11302,7 +11302,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Datacite plugin for OMP 3.3.0</description>
@@ -11326,7 +11326,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="official"/>
 			<description>Datacite plugin  Bugfix release</description>
@@ -11561,7 +11561,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -11580,7 +11580,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This is the first release of this plugin compatible with OJS and OPS in 3.3.0-x versions.</description>
@@ -11607,7 +11607,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -11626,7 +11626,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">Adds support for uncovered editor decisions in the Last Decision column and fixes bug that prevented the loading of the Plugins page at Site Settings</description>
@@ -11653,7 +11653,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -11672,7 +11672,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">Fixes problem that occurred when a submitter didn't have a country filled</description>
@@ -11699,7 +11699,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -11718,7 +11718,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">Increases overall plugin performance. Now it only takes 20% of the time it took to generate the report before.</description>
@@ -11745,7 +11745,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.1</version>
@@ -11764,7 +11764,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">This release adds the columns of abstract views and PDF views to the report. This change is currently available only to OPS.</description>
@@ -11840,7 +11840,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.1</version>
@@ -11859,7 +11859,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 
 			<certification type="reviewed"/>
@@ -11933,7 +11933,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner" />
 			<description>Release of the inlineHtmlGalley plugin for OJS 3.x </description>
@@ -11978,7 +11978,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">This is the first release of this plugin to be sent to PKP Plugin Gallery. Its main functionality is to add the Plaudit widget to the submission details on the submission's landing page.</description>
@@ -12006,7 +12006,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12026,7 +12026,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12046,7 +12046,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">This release adds support for OJS and OMP in versions 3.3.0-x.</description>
@@ -12074,7 +12074,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12094,7 +12094,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12114,7 +12114,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">This is the first version of the plugin compatible with OJS and OMP, in versions 3.3.0-x. It brings usability improvements over the previous version.</description>
@@ -12162,7 +12162,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12182,7 +12182,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12202,7 +12202,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">Makes it required for the authors/contributors of the submission to fill in the "affiliation" field.</description>
@@ -12230,7 +12230,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12250,7 +12250,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12270,7 +12270,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">Makes the "ORCID" field required.</description>
@@ -12298,7 +12298,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12318,7 +12318,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12338,7 +12338,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">Allows configuring the fields to be required through the plugin settings. Checks if ORCID Profile Plugin is disabled to be able to require "ORCID" field.</description>
@@ -12366,7 +12366,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12386,7 +12386,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12406,7 +12406,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">Allows you to configure the Biography Statement field as required.</description>
@@ -12434,7 +12434,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12454,7 +12454,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12474,7 +12474,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">Add CSRF checks.</description>
@@ -12502,7 +12502,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12522,7 +12522,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12542,7 +12542,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">Feat Bio Statement field required</description>
@@ -12602,7 +12602,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="omp">
 				<version>3.3.0.0</version>
@@ -12622,7 +12622,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<compatibility application="ops">
 				<version>3.3.0.0</version>
@@ -12642,7 +12642,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed" />
 			<description locale="en">Fixed an error when enabled via Site Settings. Plugin can only be enabled in journals.</description>
@@ -12701,7 +12701,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">Shows the DOI of the articles in the summary of issues and in the home page</description>
@@ -12740,7 +12740,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en">Fixes compatibility problem with PHP 8</description>
@@ -12793,7 +12793,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<description>Initial release.</description>
 		</release>
@@ -12817,7 +12817,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<description locale="en">Fixed base directory name.</description>
 			<description locale="en_US">Fixed base directory name.</description>
@@ -12842,7 +12842,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<description locale="en">Updated version and download metadata to match.</description>
 			<description locale="en_US">Updated version and download metadata to match.</description>
@@ -12867,7 +12867,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<description locale="en">Design changes and bug fixes.</description>
 			<description locale="en_US">Design changes and bug fixes.</description>
@@ -12892,7 +12892,7 @@ the registration of DOIs with mEDRA.</p>]]></description>
 				<version>3.3.0.14</version>
 				<version>3.3.0.15</version>
 				<version>3.3.0.16</version>
-				<version>3.3.0.17</version>
+				<version>~3.3.0.0</version>
 			</compatibility>
 			<description locale="en">Template and language fixes in locale.po.</description>
 			<description locale="en_US">Template and language fixes in locale.po.</description>


### PR DESCRIPTION
For every instance of 3.3.0-17 just added, assert forward compatibility for all 3.3.0 releases instead.