### PR TITLE
Corrected description of Akismet 1.2.3-1 release

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -8829,7 +8829,7 @@
 				<version>~3.3.0.0</version>
 			</compatibility>
 			<certification type="partner" />
-			<description>Release of the Akismet plugin for OJS/OMP/OPS 3.3 with PHP 8.0 support</description>
+			<description>This update fixes a bug in the settings form</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="formHoneypot">


### PR DESCRIPTION
This is not compatible with PHP 8, it was a bug fix for a problem with the plugin settings form in PHP 7.4. The plugin gallery release description was made in error. 