### PR TITLE
Correct RQC version identifier

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -13,7 +13,7 @@
 			<institution>Freie Universität Berlin</institution>
 			<email>prechelt@inf.fu-berlin.de</email>
 		</maintainer>
-		<release date="2023-09-12"  version="v1.0.0-33" md5="e1590bc4a1d291e37f5e6e1f4cc25f73">
+		<release date="2023-09-12"  version="1.0.0-33" md5="e1590bc4a1d291e37f5e6e1f4cc25f73">
 			<package>https://github.com/prechelt/ojs-rqcplugin/releases/download/v1.0.0-33/rqc-ojs-v1.0.0-33.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.3.0.0</version>


### PR DESCRIPTION
The leading "v" in the `version` attribute causes OJS to report "Newer than available version" when the current version is installed.