### PR TITLE
New releases for keywordCloud plugin

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -4048,6 +4048,76 @@
 			<description locale="es">Esta versión normaliza las palabras clave a minúsculas y elimina las palabras clave duplicadas</description>
 			<description locale="pt_BR">Essa versão normaliza as palavras-chave para minúsculo e remove palavras-chave duplicadas</description>
 		</release>
+		<release date="2024-10-14" version="1.2.0.0" md5="4c8c57a5d8ebdfc7a18741c2ba6fce59">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v1.2.0/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.0.4</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.2.0.0</version>
+				<version>3.2.0.1</version>
+				<version>3.2.0.2</version>
+				<version>3.2.0.3</version>
+				<version>3.2.0.4</version>
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">Shows primary locale keywords when current locale keywords are empty</description>
+			<description locale="es_ES">Muestra palabras clave del idioma principal cuando las palabras clave del idioma actual estén vacías.</description>
+			<description locale="pt_BR">Exibe palavras-chave do idioma principal quando as palavras-chave do idioma atual estiverem vazias.</description>
+		</release>
+		<release date="2024-10-14" version="2.1.0.0" md5="43eb8510f9da4fb3c268bb7487eaa42c">
+			<package>https://github.com/lepidus/keywordCloud/releases/download/v2.1.0/keywordCloud.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">Shows primary locale keywords when current locale keywords are empty</description>
+			<description locale="es">Muestra palabras clave del idioma principal cuando las palabras clave del idioma actual estén vacías.</description>
+			<description locale="pt_BR">Exibe palavras-chave do idioma principal quando as palavras-chave do idioma atual estiverem vazias.</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="bootstrap3">
 		<name locale="en">Bootstrap3</name>


### PR DESCRIPTION
These releases include displaying the primary language's keywords when the current language's keywords are empty.