### PR TITLE
Recent releases of Lepidus plugins

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -1669,6 +1669,66 @@
 			<description locale="es_ES">Esta versión corrige el enlace para los envíos publicados exhibidos en la historia de los autores.</description>
 			<description locale="pt_BR">Esta versão corrige o link para artigos publicados exibido no histórico dos autores.</description>
 		</release>
+		<release date="2024-06-27" version="1.1.2.0" md5="658110472e3029c4b856e6069c2598e9">
+			<package>https://github.com/lepidus/authorsHistory/releases/download/v1.1.2/authorsHistory.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.2.1.0</version>
+				<version>3.2.1.1</version>
+				<version>3.2.1.2</version>
+				<version>3.2.1.3</version>
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">This Adds translation for "ar_IQ" locale.</description>
+			<description locale="es_ES">Esta versión Añade traducción para la configuración regional "ar_IQ".</description>
+			<description locale="pt_BR">Esta versão adiciona tradução para a localidade "ar_IQ".</description>
+		</release>
+		<release date="2024-06-27" version="2.0.1.0" md5="e59c671a780298857e7d1a9205b64fa1">
+			<package>https://github.com/lepidus/authorsHistory/releases/download/v2.0.1/authorsHistory.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This Adds translation for "ar_IQ" locale.</description>
+			<description locale="es">Esta versión Añade traducción para la configuración regional "ar_IQ".</description>
+			<description locale="pt_BR">Esta versão adiciona tradução para a localidade "ar_IQ".</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="pluginUpdateNotification">
 		<name locale="en">Plugins update notification</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -11601,6 +11601,41 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="es">Esta versión agrega soporte para las versiones de aplicaciones 3.4.0-x</description>
 			<description locale="pt_BR">Essa versão adiciona suporte às versões 3.4.0-x das aplicações.</description>
 		</release>
+		<release date="2023-10-31" version="1.0.7.0" md5="b0269e2cad92dd5fb1b50293789e71f5">
+			<package>https://github.com/lepidus/epubViewer/releases/download/v1.0.7/epubViewer.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.2.1.4</version>
+				<version>3.2.1.5</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">This version fixes the problem of files not being recognized correctly.</description>
+			<description locale="es_ES">Esta versión corrige el problema de los archivos que no se reconocían correctamente.</description>
+			<description locale="pt_BR">Esta versão corrige problema quando arquivos não são reconhecidos corretamente.</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="inlineHtmlGalley">
 		<name locale="en">Inline Html Galley</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -1891,6 +1891,37 @@
 			<description locale="es_ES">Esta es la primera versión de este módulo que se envía a la Galería de módulos de PKP.</description>
 			<description locale="pt_BR">Esta é a primeira versão deste plugin a ser enviada à Galeria de Plugins da PKP.</description>
 		</release>
+		<release date="2024-03-22" version="1.5.2.0" md5="dfd48f6993686a91d0f959dfddbfc892">
+			<package>https://github.com/lepidus/contentAnalysis/releases/download/v1.5.2/contentAnalysis.tar.gz</package>
+			<compatibility application="ops">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">This version fixes a bug where ORCIDs with line breaks on it were not detected.</description>
+			<description locale="es_ES">Esta versión corrige un error por el que no se detectaban los ORCID con saltos de línea.</description>
+			<description locale="pt_BR">Esta versão corrige um bug em que ORCIDs com quebras de linha não eram detectados.</description>
+		</release>
+		<release date="2024-03-22" version="2.1.1.0" md5="99c0d798b91a1b8e08bebd52bab815ea">
+			<package>https://github.com/lepidus/contentAnalysis/releases/download/v2.1.1/contentAnalysis.tar.gz</package>
+			<compatibility application="ops">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This version fixes a bug where ORCIDs with line breaks on it were not detected.</description>
+			<description locale="es">Esta versión corrige un error por el que no se detectaban los ORCID con saltos de línea.</description>
+			<description locale="pt_BR">Esta versão corrige um bug em que ORCIDs com quebras de linha não eram detectados.</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="piwik">
 		<name locale="en">Matomo</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -12246,6 +12246,71 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="es_ES">Corregido un error cuando se habilita a través de la Configuración del sitio. El plugin solo se puede habilitar en revistas.</description>
 			<description locale="pt_BR">Corrigido um erro quando habilitado via Configurações do Site. O plugin só pode ser habilitado em periódicos.</description>
 		</release>
+		<release date="2024-04-02" version="2.1.0.0" md5="c7426869d65b8179266c19d9d4e2f325">
+			<package>https://github.com/lepidus/toggleRequiredMetadata/releases/download/v2.1.0.0/toggleRequiredMetadata.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed" />
+			<description locale="en">This version adds a check for required metadata during submission.</description>
+			<description locale="es">Esta versión añade una comprobación de los metadatos necesarios durante el envío.</description>
+			<description locale="pt_BR">Esta versão adiciona uma verificação de metadados obrigatórios durante o envio.</description>
+		</release>
+		<release date="2024-04-01" version="1.3.0.0" md5="cfed7481621745cce1c5972ecbeab00b">
+			<package>https://github.com/lepidus/toggleRequiredMetadata/releases/download/v1.3.0/toggleRequiredMetadata.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed" />
+			<description locale="en_US">This version adds checks for required metadata during submission.</description>
+			<description locale="es_ES">Esta versión añade comprobaciones de los metadatos necesarios durante el envío.</description>
+			<description locale="pt_BR">Esta versão adiciona verificações de metadados necessários durante o envio.</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="doiInSummary">
 		<name locale="en">DOI in Summary</name>


### PR DESCRIPTION
We've had a few releases of plugin updates that ended up not being requested for inclusion in the plugin gallery.

- [Authors History](https://github.com/lepidus/authorsHistory)
- [Content Analysis](https://github.com/lepidus/contentAnalysis)
- [Epub Viewer](https://github.com/lepidus/epubViewer)
- [Toggle Required Metadata](https://github.com/lepidus/toggleRequiredMetadata)