### PR TITLE
Fix github ref in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   XML_SCHEMA: "plugins.xsd"
 
-name:  plugin-gallery
+name: plugin-gallery
 jobs:
   plugin-gallery:
     runs-on: ubuntu-latest
@@ -31,48 +31,48 @@ jobs:
         shell: bash
 
       - name: Clone user plugin-gallery for push
-        if: ${{  github.event_name  == 'push'}}
+        if: ${{ github.event_name == 'push' }}
         run: |
-          cd ~/${{github.event.pull_request.head.repo.name || github.event.repository.name  }}
-          git remote add user_repo  https://github.com/${{ github.repository}}
+          cd ~/${{ github.event.pull_request.head.repo.name || github.event.repository.name }}
+          git remote add user_repo https://github.com/${{ github.repository }}
           git fetch user_repo ${{ github.head_ref || github.ref_name }}
           git checkout -b user_repo/${{ github.head_ref || github.ref_name }}
         shell: bash
 
       - name: lone user plugin-gallery for pull request
-        if: ${{github.event_name  == 'pull_request'}}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          cd ~/${{github.event.pull_request.head.repo.name || github.event.repository.name  }}
-          git remote add user_repo   ${{ github.event.pull_request.head.repo.html_url}} 
-          git fetch user_repo  ${{ github.event.pull_request.head.ref}}
-          git checkout  user_repo/${{ github.event.pull_request.head.ref}}
+          cd ~/${{ github.event.pull_request.head.repo.name || github.event.repository.name }}
+          git remote add user_repo ${{ github.event.pull_request.head.repo.html_url }} 
+          git fetch user_repo ${{ github.event.pull_request.head.ref }}
+          git checkout user_repo/${{ github.event.pull_request.head.ref }}
         shell: bash
 
-      - name: Validate  against plugins.xd schema
+      - name: Validate against plugins.xsd schema
         run: |
-          cd ~/${{github.event.pull_request.head.repo.name || github.event.repository.name  }}
+          cd ~/${{ github.event.pull_request.head.repo.name || github.event.repository.name }}
           xmllint --schema ./plugins.xsd ./plugins.xml --noout
         shell: bash
 
-      - name:  Validate  all releases
-        if: ${{  github.event_name  == 'push'    && github.head_ref == 'main'}}
+      - name: Validate all releases
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
-          cd ~/${{github.event.pull_request.head.repo.name || github.event.repository.name  }}
+          cd ~/${{ github.event.pull_request.head.repo.name || github.event.repository.name }}
           pkp-plugin validate-all-releases --input ./plugins.xml
         shell: bash
 
       - name: Validate new release
-        if: ${{  github.event_name  == 'pull_request'}}
+        if: ${{ github.event_name == 'pull_request'}}
         run: |
-          cd ~/${{github.event.pull_request.head.repo.name || github.event.repository.name  }}
+          cd ~/${{ github.event.pull_request.head.repo.name || github.event.repository.name }}
           git remote -v
           git branch
           pkp-plugin validate-new-release
         shell: bash
 
-      - name:  Generate site
-        if: ${{  github.event_name  == 'push'    && github.head_ref == 'main'}}
+      - name: Generate site
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
-          cd ~/${{github.event.pull_request.head.repo.name || github.event.repository.name  }}
-          GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}} pkp-plugin generate-site ./plugins.xml
+          cd ~/${{ github.event.pull_request.head.repo.name || github.event.repository.name }}
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} pkp-plugin generate-site ./plugins.xml
         shell: bash


### PR DESCRIPTION
According to [the docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs) for `github.head_ref`:

> The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.