### PR TITLE
Includes OA Switchboard as project maintainer

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -12897,8 +12897,8 @@ the registration of DOIs with mEDRA.</p>]]></description>
 		<description locale="pt_BR"><![CDATA[<p>Permite o envio de mensagens para a OA Switchboard, de forma automática, no momento da publicação de um artigo</p>]]></description>
 		<description locale="es"><![CDATA[<p>Permite enviar mensajes a OA Switchboard, de forma automática, al momento de la publicación de un artículo.</p>]]></description>
 		<maintainer>
-			<name>Lepidus Tecnologia Team</name>
-			<institution>Lepidus Tecnologia</institution>
+			<name>Lepidus Tecnologia Team for OA Switchboard</name>
+			<institution>Developed by Lepidus Tecnologia for OA Switchboard</institution>
 			<email>contato@lepidus.com.br</email>
 		</maintainer>
 		<release date="2024-11-04" version="1.1.1.8" md5="4aaab86951b178fe2b88c082c5877ade">


### PR DESCRIPTION
These modifications include that the OA Switchboard plugin has been developed for OA Switchboard in the plugin gallery's maintainer information.