### PR TITLE
Plagiarism plugin update for stable-3.3.0 and stable-3.4.0

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -940,6 +940,43 @@
 			<certification type="official" />
 			<description>Bugfix for password saving when using the settings form.</description>
 		</release>
+		<release date="2024-12-16" version="1.0.7.3" md5="1f046be3807b8e79be6dc1bfc5ceb857">
+			<package>https://github.com/pkp/plagiarism/releases/download/v1_0_7-3/plagiarism-v1_0_7-3.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.18</version>
+				<version>3.3.0.19</version>
+				<version>3.3.0.20</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.3.0.18</version>
+				<version>3.3.0.19</version>
+				<version>3.3.0.20</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.3.0.18</version>
+				<version>3.3.0.19</version>
+				<version>3.3.0.20</version>
+			</compatibility>
+			<certification type="official" />
+			<description>iThenticate latest API integration with added support for OMP and OPS</description>
+		</release>
+		<release date="2024-12-16" version="1.0.8.1" md5="acbd5cbf30fb4314404935aa5bdbde39">
+			<package>https://github.com/pkp/plagiarism/releases/download/v1_0_8-1/plagiarism-v1_0_8-1.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.4.0.7</version>
+				<version>3.4.0.8</version>
+			</compatibility>
+			<compatibility application="omp">
+				<version>3.4.0.7</version>
+				<version>3.4.0.8</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.4.0.7</version>
+				<version>3.4.0.8</version>
+			</compatibility>
+			<certification type="official" />
+			<description>Official support for OJS/OMP/OPS stable-3.4.0-7 and above</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="coins">
 		<name locale="en">COinS</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -945,19 +945,13 @@
 		<release date="2024-12-16" version="1.0.7.4" md5="7d6a2121e841dd75bdb5f372ecfa84e2">
 			<package>https://github.com/pkp/plagiarism/releases/download/v1_0_7-4/plagiarism-v1_0_7-4.tar.gz</package>
 			<compatibility application="ojs2">
-				<version>3.3.0.18</version>
-				<version>3.3.0.19</version>
-				<version>3.3.0.20</version>
+				<version>^3.3.0.18</version>
 			</compatibility>
 			<compatibility application="omp">
-				<version>3.3.0.18</version>
-				<version>3.3.0.19</version>
-				<version>3.3.0.20</version>
+				<version>^3.3.0.18</version>
 			</compatibility>
 			<compatibility application="ops">
-				<version>3.3.0.18</version>
-				<version>3.3.0.19</version>
-				<version>3.3.0.20</version>
+				<version>^3.3.0.18</version>
 			</compatibility>
 			<certification type="official" />
 				<description><![CDATA[<p>This release uses iThenticate's v2 API. <strong>You will need to ensure that your account supports iThenticate v2 and update your plugin configuration with new credentials!</strong></p>
@@ -966,16 +960,13 @@
 		<release date="2024-12-16" version="1.0.8.1" md5="acbd5cbf30fb4314404935aa5bdbde39">
 			<package>https://github.com/pkp/plagiarism/releases/download/v1_0_8-1/plagiarism-v1_0_8-1.tar.gz</package>
 			<compatibility application="ojs2">
-				<version>3.4.0.7</version>
-				<version>3.4.0.8</version>
+				<version>^3.4.0.7</version>
 			</compatibility>
 			<compatibility application="omp">
-				<version>3.4.0.7</version>
-				<version>3.4.0.8</version>
+				<version>^3.4.0.7</version>
 			</compatibility>
 			<compatibility application="ops">
-				<version>3.4.0.7</version>
-				<version>3.4.0.8</version>
+				<version>^3.4.0.7</version>
 			</compatibility>
 			<certification type="official" />
 				<description><![CDATA[<p>This release uses iThenticate's v2 API. <strong>You will need to ensure that your account supports iThenticate v2 and update your plugin configuration with new credentials!</strong></p>

--- a/plugins.xml
+++ b/plugins.xml
@@ -975,7 +975,7 @@
 				<version>3.4.0.8</version>
 			</compatibility>
 			<certification type="official" />
-			<description>Official support for OJS/OMP/OPS stable-3.4.0-7 and above</description>
+			<description>iThenticate latest API integration with official support for OJS/OMP/OPS stable-3.4.0-7 and above</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="coins">

--- a/plugins.xml
+++ b/plugins.xml
@@ -958,7 +958,8 @@
 				<version>3.3.0.20</version>
 			</compatibility>
 			<certification type="official" />
-			<description>iThenticate latest API integration with added support for OMP and OPS</description>
+			<description><![CDATA[<p>iThenticate latest API integration with added support for OMP and OPS. This version require that the iThenticate account upgraded to latest API version and it is incompatible with older iThenticate API based account.</p>
+			<p>See <a href="https://docs.pkp.sfu.ca/ithenticate/" target="_blank">https://docs.pkp.sfu.ca/ithenticate/</a> for detail upgrade information.</p>]]></description>
 		</release>
 		<release date="2024-12-16" version="1.0.8.1" md5="acbd5cbf30fb4314404935aa5bdbde39">
 			<package>https://github.com/pkp/plagiarism/releases/download/v1_0_8-1/plagiarism-v1_0_8-1.tar.gz</package>
@@ -976,6 +977,8 @@
 			</compatibility>
 			<certification type="official" />
 			<description>iThenticate latest API integration with official support for OJS/OMP/OPS stable-3.4.0-7 and above</description>
+			<description><![CDATA[<p>iThenticate latest API integration with official support for OJS/OMP/OPS stable-3.4.0-7 and above. This version require that the iThenticate account upgraded to latest API version and it is incompatible with older iThenticate API based account.</p>
+			<p>See <a href="https://docs.pkp.sfu.ca/ithenticate/" target="_blank">https://docs.pkp.sfu.ca/ithenticate/</a> for detail upgrade information.</p>]]></description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="coins">

--- a/plugins.xml
+++ b/plugins.xml
@@ -976,7 +976,6 @@
 				<version>3.4.0.8</version>
 			</compatibility>
 			<certification type="official" />
-			<description>iThenticate latest API integration with official support for OJS/OMP/OPS stable-3.4.0-7 and above</description>
 			<description><![CDATA[<p>iThenticate latest API integration with official support for OJS/OMP/OPS stable-3.4.0-7 and above. This version require that the iThenticate account upgraded to latest API version and it is incompatible with older iThenticate API based account.</p>
 			<p>See <a href="https://docs.pkp.sfu.ca/ithenticate/" target="_blank">https://docs.pkp.sfu.ca/ithenticate/</a> for detail upgrade information.</p>]]></description>
 		</release>

--- a/plugins.xml
+++ b/plugins.xml
@@ -940,8 +940,8 @@
 			<certification type="official" />
 			<description>Bugfix for password saving when using the settings form.</description>
 		</release>
-		<release date="2024-12-16" version="1.0.7.3" md5="1f046be3807b8e79be6dc1bfc5ceb857">
-			<package>https://github.com/pkp/plagiarism/releases/download/v1_0_7-3/plagiarism-v1_0_7-3.tar.gz</package>
+		<release date="2024-12-16" version="1.0.7.4" md5="7d6a2121e841dd75bdb5f372ecfa84e2">
+			<package>https://github.com/pkp/plagiarism/releases/download/v1_0_7-4/plagiarism-v1_0_7-4.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.3.0.18</version>
 				<version>3.3.0.19</version>


### PR DESCRIPTION
This update include the latest release of [Plagiarism Plugin](https://github.com/pkp/plagiarism) for the following releases 
1. [Plagiarism plugin for OJS/OMP/OPS 3.4.0-x](https://github.com/pkp/plagiarism/releases/tag/v1_0_8-1)
2. [Plagiarism plugin for OJS/OMP/OPS 3.3.0-x](https://github.com/pkp/plagiarism/releases/tag/v1_0_7-4)

