### PR TITLE
Update Publons compatibility. Does not work with 3.3.0.16.

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -10065,7 +10065,11 @@
 				<version>3.3.0.8</version>
 				<version>3.3.0.9</version>
 				<version>3.3.0.10</version>
-				<version>~3.3.0.0</version>
+				<version>3.3.0.11</version>
+                                <version>3.3.0.12</version>
+                                <version>3.3.0.13</version>
+                                <version>3.3.0.14</version>
+                                <version>3.3.0.15</version>
 			</compatibility>
 			<certification type="partner"/>
 			<description>Fix compatibility issues with OJS v3.3. Fixed the send reviews button for already sent reviews.</description>


### PR DESCRIPTION
Publons Readme states that it is not compatible with 3.3.0.16. 
https://github.com/publons/ojs_3_plugin?tab=readme-ov-file#system-requirements
"OJS 3.1, 3.2, or early versions of 3.3 (there are known issues with 3.3.0-16, plugin doesn't currently work with this version)"