### PR TITLE
Remove Publons plugin

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -10138,6 +10138,7 @@
 				<version>3.4.0.5</version>
 				<version>3.4.0.6</version>
 				<version>3.4.0.7</version>
+				<version>3.4.0.8</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Updated link to Terms and Conditions, included support for 3.4.0.7</description>

--- a/plugins.xml
+++ b/plugins.xml
@@ -7167,7 +7167,7 @@
 			<description>Release of the adminNotificationManager plugin for OJS 3.3.</description>
 		</release>
 		<release date="2024-12-19" version="1.3.0-0" md5="14239295b6c81199ff903ef3fff3e920">
-			<package>https://github.com/ulsdevteam/pkp-adminNotificationManager/releases/download/v1.3.0.0/adminNotificationManager-v1.3.0-0.tar.gz</package> 
+			<package>https://github.com/ulsdevteam/pkp-adminNotificationManager/releases/download/v1.3.0.0/adminNotificationManager-v1.3.0-0.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.4.0.0</version>
 			</compatibility>
@@ -10037,78 +10037,6 @@
 			</compatibility>
 			<certification type="reviewed" />
 			<description>OpenGraph plugin for 3.4</description>
-		</release>
-	</plugin>
-	<plugin category="generic" product="publons">
-		<name locale="en">Publons Reviewer Recognition Plugin</name>
-		<name locale="en_US">Publons Reviewer Recognition Plugin</name>
-		<homepage>https://github.com/publons/ojs_3_plugin/</homepage>
-		<summary locale="en">This plugin enables integration with Publons Reviewer Recognition Service.</summary>
-		<summary locale="en_US">This plugin enables integration with Publons Reviewer Recognition Service.</summary>
-		<description locale="en"><![CDATA[In order to provide your reviewers with the opportunity to gain recognition for their reviews on Publons, please register your interest with Publons by visiting https://publons.com/benefits/publishers. Our accounts team will then be in touch to discuss your options and provide further instructions on how to integrate your journal with Publons.]]></description>
-		<description locale="en_US"><![CDATA[In order to provide your reviewers with the opportunity to gain recognition for their reviews on Publons, please register your interest with Publons by visiting https://publons.com/benefits/publishers. Our accounts team will then be in touch to discuss your options and provide further instructions on how to integrate your journal with Publons.]]></description>
-		<maintainer>
-			<name>Publons</name>
-			<institution>Publons</institution>
-			<email>ojs@publons.com</email>
-		</maintainer>
-		<release date="2021-06-01" version="2021.6.1.0" md5="a19303dfd77fbd0dc790b5f92e922f2c">
-			<package>https://github.com/publons/ojs_3_plugin/releases/download/2021.6.1.0/publons.tar.gz</package>
-			<compatibility application="ojs2">
-				<version>3.3.0.1</version>
-				<version>3.3.0.2</version>
-				<version>3.3.0.3</version>
-				<version>3.3.0.4</version>
-				<version>3.3.0.5</version>
-				<version>3.3.0.6</version>
-				<version>3.3.0.7</version>
-				<version>3.3.0.8</version>
-				<version>3.3.0.9</version>
-				<version>3.3.0.10</version>
-				<version>3.3.0.11</version>
-                                <version>3.3.0.12</version>
-                                <version>3.3.0.13</version>
-                                <version>3.3.0.14</version>
-                                <version>3.3.0.15</version>
-			</compatibility>
-			<certification type="partner"/>
-			<description>Fix compatibility issues with OJS v3.3. Fixed the send reviews button for already sent reviews.</description>
-		</release>
-		<release date="2020-06-05" version="2020.6.5.0" md5="71d1dbed08050f4eb589927f02d8e4ab">
-			<package>https://github.com/publons/ojs_3_plugin/releases/download/2020.6.5.0/publons.tar.gz</package>
-			<compatibility application="ojs2">
-				<version>3.2.0.0</version>
-				<version>3.2.0.1</version>
-				<version>3.2.0.2</version>
-				<version>3.2.0.3</version>
-				<version>3.2.0.4</version>
-				<version>3.2.1.0</version>
-				<version>3.2.1.1</version>
-				<version>3.2.1.2</version>
-				<version>3.2.1.3</version>
-				<version>3.2.1.4</version>
-				<version>3.2.1.5</version>
-			</compatibility>
-			<certification type="partner"/>
-			<description>Fix compatibility issues with OJS v3.2.0. Reset versioning to use calendar versioning.</description>
-		</release>
-		<release date="2019-10-25" version="3.2.2.0" md5="2f8bc414e9694002adde559844448b80">
-			<package>https://github.com/publons/ojs_3/releases/download/3.2.2.0/publons.tar.gz</package>
-			<compatibility application="ojs2">
-				<version>3.1.0.0</version>
-				<version>3.1.0.1</version>
-				<version>3.1.1.0</version>
-				<version>3.1.1.1</version>
-				<version>3.1.1.2</version>
-				<version>3.1.1.4</version>
-				<version>3.1.2.0</version>
-				<version>3.1.2.1</version>
-				<version>3.1.2.2</version>
-				<version>3.1.2.3</version>
-				<version>3.1.2.4</version>
-			</compatibility>
-			<certification type="partner"/>
-			<description>Minor improvements for Portuguese translations.</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="webOfScience">


### PR DESCRIPTION
Removing Publons plugin. This plugin was re-branded as Web of Science Reviewer Recognition.