### PR TITLE
Update supported versions of OJS 3.4 for WoS RRS plugin. Last tested on 3.4.0.9

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -10376,14 +10376,7 @@
 		<release date="2024-11-26" version="1.3.4.2" md5="3040e43abee94f09941c95c726709eeb">
 			<package>https://github.com/clarivate/wos_reviewer_recognition_plugin_ojs_3/releases/download/v1.3.4.2/webOfScience_1_3_4_2.tar.gz</package>
 			<compatibility application="ojs2">
-				<version>3.4.0.1</version>
-				<version>3.4.0.2</version>
-				<version>3.4.0.3</version>
-				<version>3.4.0.4</version>
-				<version>3.4.0.5</version>
-				<version>3.4.0.6</version>
-				<version>3.4.0.7</version>
-				<version>3.4.0.8</version>
+				<version>~3.4.0.0</version>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description>Updated link to Terms and Conditions, included support for 3.4.0.7</description>


### PR DESCRIPTION
Update supported versions of OJS 3.4 for WoS RRS plugin to all 3.4. Last tested on version 3.4.0.9