### PR TITLE
new version of the RQC-Plugin: V2.0.0

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -32,6 +32,36 @@
 			<certification type="reviewed"/>
 			<description>Initial release.</description>
 		</release>
+		<release date="2025-08-25"  version="2.0.0-33" md5="23152b6c05357c18cca0a556456afbbe">
+			<package>https://github.com/prechelt/ojs-rqcplugin/releases/download/v2.0.0-33/rqc-ojs-v2.0.0-33.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>3.3.0.11</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.12</version>
+				<version>3.3.0.13</version>
+				<version>3.3.0.14</version>
+				<version>3.3.0.15</version>
+				<version>3.3.0.16</version>
+				<version>3.3.0.17</version>
+				<version>3.3.0.18</version>
+				<version>3.3.0.19</version>
+				<version>3.3.0.20</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Minimal viable product.</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="epubJsViewer">
 		<name locale="en">EPUB Viewer</name>


### PR DESCRIPTION
Finally the real minimal viable product of the rqc plugin for OJS 3.3
only small changes left