### PR TITLE
OA Switchboard: fix an error that occurs when the submission file no longer exists.

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -14199,6 +14199,16 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="pt_BR">Essa versão corrige um erro que ocorre quando o arquivo de submissão não existe mais.</description>
 			<description locale="es_ES">Esta versión corrige un error que ocurre cuando el archivo de envío ya no existe.</description>
 		</release>
+		<release date="2025-09-16" version="2.0.1.18" md5="3776c620f0b7a3a6037b7ec78eacbd03">
+			<package>https://github.com/lepidus/OASwitchboard/releases/download/v2.0.1.18/OASwitchboard.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This release fixes an error that occurs when the submission file no longer exists.</description>
+			<description locale="pt_BR">Essa versão corrige um erro que ocorre quando o arquivo de submissão não existe mais.</description>
+			<description locale="es">Esta versión corrige un error que ocurre cuando el archivo de envío ya no existe.</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="deleteIncompleteSubmissions">
 		<name locale="en">Delete Incomplete Submissions</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -14178,6 +14178,27 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="pt_BR">Essa versão corrige o não envio da mensagem P1 quando um artigo é publicado sem pelo menos um autor com ID ROR.</description>
 			<description locale="es">Esta versión corrige el fallo de envío del mensaje P1 cuando se publica un artículo sin al menos un autor con ID ROR.</description>
 		</release>
+		<release date="2025-09-16" version="1.1.1.12" md5="60e8d079485fc7fd02eacd412fb2299a">
+			<package>https://github.com/lepidus/OASwitchboard/releases/download/v1.1.1.12/OASwitchboard.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">This release fixes an error that occurs when the submission file no longer exists.</description>
+			<description locale="pt_BR">Essa versão corrige o não envio da mensagem P1 quando um artigo é publicado sem pelo menos um autor com ID ROR.</description>
+			<description locale="es_ES">Esta versión corrige el fallo de envío del mensaje P1 cuando se publica un artículo sin al menos un autor con ID ROR.</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="deleteIncompleteSubmissions">
 		<name locale="en">Delete Incomplete Submissions</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -14196,8 +14196,8 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			</compatibility>
 			<certification type="reviewed"/>
 			<description locale="en_US">This release fixes an error that occurs when the submission file no longer exists.</description>
-			<description locale="pt_BR">Essa versão corrige o não envio da mensagem P1 quando um artigo é publicado sem pelo menos um autor com ID ROR.</description>
-			<description locale="es_ES">Esta versión corrige el fallo de envío del mensaje P1 cuando se publica un artículo sin al menos un autor con ID ROR.</description>
+			<description locale="pt_BR">Essa versão corrige um erro que ocorre quando o arquivo de submissão não existe mais.</description>
+			<description locale="es_ES">Esta versión corrige un error que ocurre cuando el archivo de envío ya no existe.</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="deleteIncompleteSubmissions">


### PR DESCRIPTION
These new versions of the plugin add validation to prevent fatal errors in scenarios where the submission file ID is null.

Related issue: [Inability to access published article with missing PDF](https://github.com/lepidus/OASwitchboard/issues/1).