### PR TITLE
Add Reviewer Certificate plugin (generic)

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -7957,6 +7957,27 @@
 			<institution>Academy of Cognitive and Natural Sciences</institution>
 			<email>semerikov@gmail.com</email>
 		</maintainer>
+		<release date="2026-03-20" version="1.5.0.0" md5="972fa8bb2b3815e4845a60195e11de27">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.3/reviewerCertificate-v1.5.0-3.3.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.3.x-only code paths. OJS 3.3.x compatible.</description>
+		</release>
+		<release date="2026-03-20" version="1.5.0.0" md5="09ad87e525c26e25c1f0baf6f1734708">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.4/reviewerCertificate-v1.5.0-3.4.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.4.x-only code paths. OJS 3.4.x compatible.</description>
+		</release>
+		<release date="2026-03-20" version="1.5.0.0" md5="9192df681dccc199c29897e4c5f6a01e">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.5/reviewerCertificate-v1.5.0-3.5.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.5.x-only code paths. OJS 3.5.x compatible.</description>
+		</release>
 		<release date="2026-03-13" version="1.4.0.0" md5="5101e4cba8f77da3106297bd05c12ab0">
 			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.3/reviewerCertificate-v1.4.0-3.3.tar.gz</package>
 			<compatibility application="ojs2">

--- a/plugins.xml
+++ b/plugins.xml
@@ -7957,21 +7957,21 @@
 			<institution>Academy of Cognitive and Natural Sciences</institution>
 			<email>semerikov@gmail.com</email>
 		</maintainer>
-		<release date="2026-03-20" version="1.5.0.0" md5="972fa8bb2b3815e4845a60195e11de27">
+		<release date="2026-03-20" version="1.5.0.0" md5="44c2f5c3a69106682cf5a63da8a79f8d">
 			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.3/reviewerCertificate-v1.5.0-3.3.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.3.0.0</version>
 			</compatibility>
 			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.3.x-only code paths. OJS 3.3.x compatible.</description>
 		</release>
-		<release date="2026-03-20" version="1.5.0.0" md5="09ad87e525c26e25c1f0baf6f1734708">
+		<release date="2026-03-20" version="1.5.0.0" md5="f4f848e60ece5b5c5d11d55b8aef7338">
 			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.4/reviewerCertificate-v1.5.0-3.4.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.4.0.0</version>
 			</compatibility>
 			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.4.x-only code paths. OJS 3.4.x compatible.</description>
 		</release>
-		<release date="2026-03-20" version="1.5.0.0" md5="9192df681dccc199c29897e4c5f6a01e">
+		<release date="2026-03-20" version="1.5.0.0" md5="0576ae4c3fdb5499d883f5686d38ce82">
 			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.5/reviewerCertificate-v1.5.0-3.5.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.5.0.0</version>

--- a/plugins.xml
+++ b/plugins.xml
@@ -7957,14 +7957,26 @@
 			<institution>Academy of Cognitive and Natural Sciences</institution>
 			<email>semerikov@gmail.com</email>
 		</maintainer>
-		<release date="2026-03-12" version="1.2.0.0" md5="644eddd494ad9a12dfc2b5b8e63eefc8">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.2.0/reviewerCertificate-1.2.0.0.tar.gz</package>
+		<release date="2026-03-13" version="1.4.0.0" md5="5101e4cba8f77da3106297bd05c12ab0">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.3/reviewerCertificate-v1.4.0-3.3.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.3.0.0</version>
+			</compatibility>
+			<description>Context isolation, HTML title sanitization, input validation. OJS 3.3.x compatible.</description>
+		</release>
+		<release date="2026-03-13" version="1.4.0.0" md5="90b8fd33b000f741e7f1a00de0df45ba">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.4/reviewerCertificate-v1.4.0-3.4.tar.gz</package>
+			<compatibility application="ojs2">
 				<version>~3.4.0.0</version>
+			</compatibility>
+			<description>Context isolation, HTML title sanitization, input validation. OJS 3.4.x compatible.</description>
+		</release>
+		<release date="2026-03-13" version="1.4.0.0" md5="c2881550df8064a57949c357566a7206">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.5/reviewerCertificate-v1.4.0-3.5.tar.gz</package>
+			<compatibility application="ojs2">
 				<version>~3.5.0.0</version>
 			</compatibility>
-			<description>Fix OJS 3.3 plugin enable (Issue #65), handler endpoint 500 errors, and role constant resolution. All 33 E2E tests pass across OJS 3.3, 3.4, and 3.5.</description>
+			<description>Context isolation, HTML title sanitization, input validation. OJS 3.5.x compatible.</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="reviewerCredits">

--- a/plugins.xml
+++ b/plugins.xml
@@ -7944,6 +7944,29 @@
 			<description>Lens Galley Application with  node 22+ support</description>
 		</release>
 	</plugin>
+	<plugin category="generic" product="reviewerCertificate">
+		<name locale="en">Reviewer Certificate</name>
+		<name locale="en_US">Reviewer Certificate</name>
+		<homepage>https://github.com/ssemerikov/reviewerCertificate</homepage>
+		<summary locale="en">Generates personalized PDF certificates for peer reviewers after completing reviews.</summary>
+		<summary locale="en_US">Generates personalized PDF certificates for peer reviewers after completing reviews.</summary>
+		<description locale="en"><![CDATA[<p>The Reviewer Certificate Plugin enables journals to automatically generate and distribute personalized PDF certificates of recognition to peer reviewers upon completion of their review assignments.</p><p>Features: customizable certificate templates with background images, dynamic content insertion (reviewer name, journal name, submission title, dates), QR code verification, batch generation, download tracking, and 32 language translations.</p>]]></description>
+		<description locale="en_US"><![CDATA[<p>The Reviewer Certificate Plugin enables journals to automatically generate and distribute personalized PDF certificates of recognition to peer reviewers upon completion of their review assignments.</p><p>Features: customizable certificate templates with background images, dynamic content insertion (reviewer name, journal name, submission title, dates), QR code verification, batch generation, download tracking, and 32 language translations.</p>]]></description>
+		<maintainer>
+			<name>Serhiy O. Semerikov</name>
+			<institution>Academy of Cognitive and Natural Sciences</institution>
+			<email>semerikov@gmail.com</email>
+		</maintainer>
+		<release date="2026-03-12" version="1.2.0.0" md5="644eddd494ad9a12dfc2b5b8e63eefc8">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.2.0/reviewerCertificate-1.2.0.0.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.3.0.0</version>
+				<version>~3.4.0.0</version>
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<description>Fix OJS 3.3 plugin enable (Issue #65), handler endpoint 500 errors, and role constant resolution. All 33 E2E tests pass across OJS 3.3, 3.4, and 3.5.</description>
+		</release>
+	</plugin>
 	<plugin category="generic" product="reviewerCredits">
 		<name locale="en">Reviewer Credits Plugin</name>
 		<name locale="en_US">Reviewer Credits Plugin</name>

--- a/plugins.xml
+++ b/plugins.xml
@@ -7957,47 +7957,26 @@
 			<institution>Academy of Cognitive and Natural Sciences</institution>
 			<email>semerikov@gmail.com</email>
 		</maintainer>
-		<release date="2026-03-20" version="1.5.0.0" md5="44c2f5c3a69106682cf5a63da8a79f8d">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.3/reviewerCertificate-v1.5.0-3.3.tar.gz</package>
+		<release date="2026-07-04" version="1.8.0.0" md5="5fe790440300bac2cad437ddb145b297">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.0-3.3/reviewerCertificate-1.8.0-3_3.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.3.0.0</version>
 			</compatibility>
-			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.3.x-only code paths. OJS 3.3.x compatible.</description>
+			<description>Email certificate to reviewer with PDF attachment, files_dir configuration support, short locale code directories, stored XSS fix. OJS 3.3.x compatible (includes OJS 3.3 compatibility autoloader).</description>
 		</release>
-		<release date="2026-03-20" version="1.5.0.0" md5="f4f848e60ece5b5c5d11d55b8aef7338">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.4/reviewerCertificate-v1.5.0-3.4.tar.gz</package>
+		<release date="2026-07-04" version="1.8.0.0" md5="2c7780d33d4ef85c442319c732f5e77f">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.0-3.4/reviewerCertificate-1.8.0-3_4.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.4.0.0</version>
 			</compatibility>
-			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.4.x-only code paths. OJS 3.4.x compatible.</description>
+			<description>Email certificate to reviewer with PDF attachment, files_dir configuration support, short locale code directories, stored XSS fix. OJS 3.4.x compatible.</description>
 		</release>
-		<release date="2026-03-20" version="1.5.0.0" md5="0576ae4c3fdb5499d883f5686d38ce82">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.5.0-3.5/reviewerCertificate-v1.5.0-3.5.tar.gz</package>
+		<release date="2026-07-04" version="1.8.0.0" md5="a8e3d307e002b7bbd72a9082b8c39138">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.0-3.5/reviewerCertificate-1.8.0-3_5.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.5.0.0</version>
 			</compatibility>
-			<description>Composer TCPDF dependency, removed dangerous utility files, code brevity improvements, OJS 3.5.x-only code paths. OJS 3.5.x compatible.</description>
-		</release>
-		<release date="2026-03-13" version="1.4.0.0" md5="5101e4cba8f77da3106297bd05c12ab0">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.3/reviewerCertificate-v1.4.0-3.3.tar.gz</package>
-			<compatibility application="ojs2">
-				<version>~3.3.0.0</version>
-			</compatibility>
-			<description>Context isolation, HTML title sanitization, input validation. OJS 3.3.x compatible.</description>
-		</release>
-		<release date="2026-03-13" version="1.4.0.0" md5="90b8fd33b000f741e7f1a00de0df45ba">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.4/reviewerCertificate-v1.4.0-3.4.tar.gz</package>
-			<compatibility application="ojs2">
-				<version>~3.4.0.0</version>
-			</compatibility>
-			<description>Context isolation, HTML title sanitization, input validation. OJS 3.4.x compatible.</description>
-		</release>
-		<release date="2026-03-13" version="1.4.0.0" md5="c2881550df8064a57949c357566a7206">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.5/reviewerCertificate-v1.4.0-3.5.tar.gz</package>
-			<compatibility application="ojs2">
-				<version>~3.5.0.0</version>
-			</compatibility>
-			<description>Context isolation, HTML title sanitization, input validation. OJS 3.5.x compatible.</description>
+			<description>Email certificate to reviewer with PDF attachment, files_dir configuration support, short locale code directories, stored XSS fix. OJS 3.5.x compatible.</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="reviewerCredits">

--- a/plugins.xml
+++ b/plugins.xml
@@ -7957,26 +7957,26 @@
 			<institution>Academy of Cognitive and Natural Sciences</institution>
 			<email>semerikov@gmail.com</email>
 		</maintainer>
-		<release date="2026-07-04" version="1.8.0.0" md5="5fe790440300bac2cad437ddb145b297">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.0-3.3/reviewerCertificate-1.8.0-3_3.tar.gz</package>
+		<release date="2026-07-20" version="1.8.2.0" md5="6bad10716989344a16158d2956add760">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.2-3.3/reviewerCertificate-1.8.2-3_3.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.3.0.0</version>
 			</compatibility>
-			<description>Email certificate to reviewer with PDF attachment, files_dir configuration support, short locale code directories, stored XSS fix. OJS 3.3.x compatible (includes OJS 3.3 compatibility autoloader).</description>
+			<description>Fixes certificate emails rejected by SMTP relay size limits: oversized background images are downscaled before embedding, transport failures are detected and shown to the reviewer (previously a false success on OJS 3.4+), and a link-only fallback letter is sent when the attachment is still rejected. OJS 3.3.x compatible (includes OJS 3.3 compatibility autoloader).</description>
 		</release>
-		<release date="2026-07-04" version="1.8.0.0" md5="2c7780d33d4ef85c442319c732f5e77f">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.0-3.4/reviewerCertificate-1.8.0-3_4.tar.gz</package>
+		<release date="2026-07-20" version="1.8.2.0" md5="51d944059dac071720fa152bd6470008">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.2-3.4/reviewerCertificate-1.8.2-3_4.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.4.0.0</version>
 			</compatibility>
-			<description>Email certificate to reviewer with PDF attachment, files_dir configuration support, short locale code directories, stored XSS fix. OJS 3.4.x compatible.</description>
+			<description>Fixes certificate emails rejected by SMTP relay size limits: oversized background images are downscaled before embedding, transport failures are detected and shown to the reviewer (previously a false success on OJS 3.4+), and a link-only fallback letter is sent when the attachment is still rejected. OJS 3.4.x compatible.</description>
 		</release>
-		<release date="2026-07-04" version="1.8.0.0" md5="a8e3d307e002b7bbd72a9082b8c39138">
-			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.0-3.5/reviewerCertificate-1.8.0-3_5.tar.gz</package>
+		<release date="2026-07-20" version="1.8.2.0" md5="b35e6c202863a4fe9781a66050a2715e">
+			<package>https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.8.2-3.5/reviewerCertificate-1.8.2-3_5.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.5.0.0</version>
 			</compatibility>
-			<description>Email certificate to reviewer with PDF attachment, files_dir configuration support, short locale code directories, stored XSS fix. OJS 3.5.x compatible.</description>
+			<description>Fixes certificate emails rejected by SMTP relay size limits: oversized background images are downscaled before embedding, transport failures are detected and shown to the reviewer (previously a false success on OJS 3.4+), and a link-only fallback letter is sent when the attachment is still rejected. OJS 3.5.x compatible.</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="reviewerCredits">


### PR DESCRIPTION
## Summary

Adds the **Reviewer Certificate** plugin to the Plugin Gallery.

- **Category:** generic
- **Product:** reviewerCertificate
- **Homepage:** https://github.com/ssemerikov/reviewerCertificate
- **Compatibility:** OJS 3.3, 3.4, and 3.5 (separate packages per version)

The plugin generates personalized PDF certificates for peer reviewers after completing review assignments. Features include customizable templates with background images, QR code verification, batch generation, download tracking, and 32 language translations.

## Release details (v1.4.0)

Three version-specific packages per reviewer recommendation:

| OJS Version | Package | MD5 |
|---|---|---|
| 3.3.x | [v1.4.0-3.3](https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.3/reviewerCertificate-v1.4.0-3.3.tar.gz) | `5101e4cba8f77da3106297bd05c12ab0` |
| 3.4.x | [v1.4.0-3.4](https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.4/reviewerCertificate-v1.4.0-3.4.tar.gz) | `90b8fd33b000f741e7f1a00de0df45ba` |
| 3.5.x | [v1.4.0-3.5](https://github.com/ssemerikov/reviewerCertificate/releases/download/v1.4.0-3.5/reviewerCertificate-v1.4.0-3.5.tar.gz) | `c2881550df8064a57949c357566a7206` |

**Changes in v1.4.0** (addressing review feedback):
1. Version-specific branches (`stable-3_3_0`, `stable-3_4_0`, `stable-3_5_0`)
2. Context isolation — all handlers validate `context_id` to prevent cross-journal access
3. HTML title sanitization — `strip_tags()` for PDF, Smarty `|escape` for templates
4. Input validation — certificate codes checked against `/^[A-F0-9]{16}$/`

## Checklist

- [x] Packages are `.tar.gz` with correct root folder (`reviewerCertificate/`)
- [x] `version.xml` present at top level with matching `<application>` name
- [x] MD5 checksums match packages (all 3 verified)
- [x] Package URLs return HTTP 200 (all 3 verified)
- [x] No `<certification>` element (community plugin, not PKP-reviewed)
- [x] Compatibility versions use `~` wildcard notation
- [x] Separate `<release>` blocks per OJS major version