### PR TITLE
Add Dummy Data Generator plugin with API routes for OJS

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0"?>
 <plugins xmlns="http://pkp.sfu.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pkp.sfu.ca plugins.xsd">
-
+<plugin category="generic" product="ojs">
+	<name locale="en">Dummy Data Generator</name>
+	<homepage>https://github.com/munir-abbasi/dummyDataGenerator</homepage>
+	<summary locale="en">Generate dummy users, submissions, and issues for OJS testing environments.</summary>
+	<description locale="en">The Dummy Data Generator plugin extends the OJS users API with plugin-defined routes for generating dummy users, submissions, and issues, and for cleaning up generated data. It is intended for development and testing environments only.</description>
+	<maintainer>
+		<name>Munir Abbasi</name>
+		<institution>SyntaxHouse</institution>
+		<email>munir@syntaxhouse.com</email>
+	</maintainer>
+	<release date="2026-03-26" version="1.0.0" md5="PUT_REAL_MD5_HERE">
+		<package>https://github.com/munir-abbasi/dummyDataGenerator/releases/download/v1.0.0/dummyDataGenerator-v1.0.0.tar.gz</package>
+		<compatibility application="ojs">
+			<version>~3.5.0.0</version>
+		</compatibility>
+		<description locale="en">Initial release of the Dummy Data Generator plugin for OJS 3.5. Adds plugin-defined API routes under /api/v1/users for generating dummy users, submissions, issues, and cleanup data for testing.</description>
+	</release>
+</plugin>
 	<plugin category="generic" product="iiifViewer">
 		<name locale="en_US">IIIF Viewer</name>
 		<homepage>https://github.com/ub-unibe-ch/iiifViewer</homepage>

--- a/plugins.xml
+++ b/plugins.xml
@@ -10,8 +10,8 @@
 		<institution>SyntaxHouse</institution>
 		<email>munir@syntaxhouse.com</email>
 	</maintainer>
-	<release date="2026-03-26" version="1.0.0" md5="PUT_REAL_MD5_HERE">
-		<package>https://github.com/munir-abbasi/dummyDataGenerator/releases/download/v1.0.0/dummyDataGenerator-v1.0.0.tar.gz</package>
+	<release date="2026-03-26" version="1.0.0" md5="afa4ea7a15f3edec646aa1fcbd1aa0e7">
+		<package>https://github.com/munir-abbasi/dummyDataGenerator/releases/download/1.0.0/dummyDataGenerator-v1.0.0.tar.gz</package>
 		<compatibility application="ojs">
 			<version>~3.5.0.0</version>
 		</compatibility>

--- a/plugins.xml
+++ b/plugins.xml
@@ -10,8 +10,8 @@
 		<institution>SyntaxHouse</institution>
 		<email>munir@syntaxhouse.com</email>
 	</maintainer>
-	<release date="2026-03-26" version="1.0.0" md5="afa4ea7a15f3edec646aa1fcbd1aa0e7">
-		<package>https://github.com/munir-abbasi/dummyDataGenerator/releases/download/1.0.0/dummyDataGenerator-v1.0.0.tar.gz</package>
+	<release date="2026-03-26" version="1.0.0" md5="7ebde987f13cafb5d58b1a11409d6d8a">
+		<package>https://github.com/munir-abbasi/dummyDataGenerator/releases/download/v1.0.0/dummyDataGenerator-v1.0.0.tar.gz</package>
 		<compatibility application="ojs">
 			<version>~3.5.0.0</version>
 		</compatibility>


### PR DESCRIPTION
This PR adds the **Dummy Data Generator** plugin, a generic plugin for Open Journal Systems 3.5+.
The plugin extends the OJS API by adding custom routes under the `/api/v1/users` endpoint to generate dummy users, submissions, and issues for development and testing environments.
---
## Plugin Details
* **Name:** Dummy Data Generator
* **Category:** generic
* **Product:** ojs
* **Repository:** [https://github.com/munir-abbasi/dummyDataGenerator](https://github.com/munir-abbasi/dummyDataGenerator)
* **Release Version:** 1.0.0
* **Compatibility:** OJS 3.5.x
---

## Overview
This plugin provides a controlled way to generate test data directly through the OJS API.
It adds plugin-defined endpoints for:
* generating users with Author role
* generating submissions with metadata and files
* simulating workflow progression via programmatic editorial decisions
* creating and publishing issues
* cleaning up generated data safely
All routes extend the existing OJS users API handler and inherit authentication and authorization from the OJS API layer.
---

## API Endpoints
```text
POST   /api/v1/users/generate-users
POST   /api/v1/users/generate-submissions
POST   /api/v1/users/generate-issue
DELETE /api/v1/users/cleanup
```
These endpoints are implemented by the plugin and are not part of the core OJS API.
---

## Installation & Testing
* Plugin installs under `plugins/generic/dummyDataGenerator`
* Verified on OJS 3.5.x
* Plugin loads and registers routes successfully
* Endpoints return JSON responses as expected
* Role-based access enforced (Manager/Admin only)

---
## Notes
* Intended for development and testing environments
* Workflow progression is simulated via internal decision APIs
* Cleanup operation deletes only plugin-generated data within the current context
* Package URL and MD5 checksum have been verified
---

## Checklist
* [x] Clean release package (no dev artifacts)
* [x] version.xml matches release
* [x] GitHub release created (`v1.0.0`)
* [x] MD5 checksum matches package
* [x] Documentation included (README, API docs, installation)
---

## Package
Release archive:
`dummyDataGenerator-v1.0.0.tar.gz`