### PR TITLE
Add Erticaz Press theme (themes/erticazPress) v1.0.0

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -16276,8 +16276,8 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<institution>Erticaz</institution>
 			<email>info@erticaz.com</email>
 		</maintainer>
-		<release date="2026-06-11" version="1.0.0.0" md5="5040cce2049a85976a6dca45124217a6">
-			<package>https://github.com/haydary1986/erticaz-press-ojs-theme/releases/download/v1.0.0/erticazPress.tar.gz</package>
+		<release date="2026-06-11" version="1.1.0.0" md5="28ae00654a8663cc89c1e4245782a5a9">
+			<package>https://github.com/haydary1986/erticaz-press-ojs-theme/releases/download/v1.1.0/erticazPress.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>3.4.0.0</version>
 				<version>3.4.0.1</version>

--- a/plugins.xml
+++ b/plugins.xml
@@ -16266,4 +16266,37 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description>Initial release for OJS 3.3.x.</description>
 		</release>
 	</plugin>
+	<plugin category="themes" product="erticazPress">
+		<name locale="en_US">Erticaz Press</name>
+		<homepage>https://github.com/haydary1986/erticaz-press-ojs-theme</homepage>
+		<summary locale="en_US">A free, world-class institutional theme with full RTL support.</summary>
+		<description locale="en_US"><![CDATA[<p>Erticaz Press gives any OJS journal the clean, structured look of leading international publishers. A full-width home page with an institutional masthead, a key-facts band, an indexing &amp; abstracting grid and a title-only current-issue list, plus comprehensive styling for every sub-page. One-colour palette, full RTL support and English/Arabic/Turkish locales. By Erticaz (https://erticaz.com).</p>]]></description>
+		<maintainer>
+			<name>Erticaz</name>
+			<institution>Erticaz</institution>
+			<email>info@erticaz.com</email>
+		</maintainer>
+		<release date="2026-06-11" version="1.0.0.0" md5="5040cce2049a85976a6dca45124217a6">
+			<package>https://github.com/haydary1986/erticaz-press-ojs-theme/releases/download/v1.0.0/erticazPress.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.4.0.0</version>
+				<version>3.4.0.1</version>
+				<version>3.4.0.2</version>
+				<version>3.4.0.3</version>
+				<version>3.4.0.4</version>
+				<version>3.4.0.5</version>
+				<version>3.4.0.6</version>
+				<version>3.4.0.7</version>
+				<version>3.4.0.8</version>
+				<version>3.4.0.9</version>
+				<version>~3.4.0.0</version>
+				<version>3.5.0.0</version>
+				<version>3.5.0.1</version>
+				<version>3.5.0.2</version>
+				<version>3.5.0.3</version>
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<description locale="en_US">Initial release.</description>
+		</release>
+	</plugin>
 </plugins>


### PR DESCRIPTION
## Add new theme: Erticaz Press

This PR adds **Erticaz Press**, a free, open-source (GPL-3.0) institutional theme for OJS.

- **Category:** `themes` · **Product:** `erticazPress`
- **Repository:** https://github.com/haydary1986/erticaz-press-ojs-theme
- **Release package:** https://github.com/haydary1986/erticaz-press-ojs-theme/releases/download/v1.0.0/erticazPress.tar.gz
- **Version:** 1.0.0.0 · **MD5:** `5040cce2049a85976a6dca45124217a6`
- **Compatibility:** OJS 3.4.x and 3.5.x
- **License:** GNU GPL v3

### About the theme
A child of the OJS Default theme that gives any journal a clean, institutional (Elsevier/Springer-style) look: a full-width home page with an institutional masthead, a key-facts band, an indexing & abstracting grid and a title-only current-issue list, plus comprehensive styling for **every** sub-page (article, archive, search, announcements, forms, pagination, masthead). One-colour palette system, full RTL support and bundled English / Arabic / Turkish locales.

The new `<plugin>` entry is appended at the end of `plugins.xml` and is well-formed; the release URL is live and its MD5 matches the file above.

Thank you for maintaining the gallery! 🙏
