### PR TITLE
Update plugins.xml

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -12050,4 +12050,26 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="es_ES">Versión inicial para OJS 3.5+</description>
 		</release>
 	</plugin>
+	<plugin category="generic" product="loginOtp">
+    <name locale="en">Login OTP via Email</name>
+    <name locale="en_US">Login OTP via Email</name>
+    <homepage>https://github.com/archicoop/loginOtp</homepage>
+    <summary locale="en">Two-factor authentication for OJS/OMP login via 6-digit one-time code sent by email.</summary>
+    <summary locale="en_US">Two-factor authentication for OJS/OMP login via 6-digit one-time code sent by email.</summary>
+    <description locale="en"><![CDATA[<p>Adds two-factor authentication to the login process by sending a one-time code (OTP) via email after a successful username/password login. Per-journal configuration: each journal independently decides which roles must complete the 2FA step. Site-level login is always protected. Plugin runs as an always-active system component. Compliant with Italian ACN Guidelines for Public Administrations and GDPR.</p>]]></description>
+    <description locale="en_US"><![CDATA[<p>Adds two-factor authentication to the login process by sending a one-time code (OTP) via email after a successful username/password login. Per-journal configuration: each journal independently decides which roles must complete the 2FA step. Site-level login is always protected. Plugin runs as an always-active system component. Compliant with Italian ACN Guidelines for Public Administrations and GDPR.</p>]]></description>
+    <maintainer>
+        <name>Archimede Informatica</name>
+        <institution>Archimede Informatica</institution>
+        <email>marziani@archicoop.it</email>
+    </maintainer>
+    <release date="2026-06-30" version="2.0.0.0" md5="3c8ac0ad3e61b2d4bab5900cb3b5fb4b">
+        <package>https://github.com/archicoop/loginOtp/releases/download/v2.0.0/loginOtp-2.0.0.tar.gz</package>
+        <compatibility application="ojs2">
+            <version>~3.5.0.0</version>
+        </compatibility>
+        <certification type="reviewed"/>
+        <description>Major refactor: per-journal configuration, OR-based rule set, plugin always active.</description>
+    </release>
+</plugin>
 </plugins>

--- a/plugins.xml
+++ b/plugins.xml
@@ -12063,13 +12063,13 @@ the registration of DOIs with mEDRA.</p>]]></description>
         <institution>Archimede Informatica</institution>
         <email>marziani@archicoop.it</email>
     </maintainer>
-    <release date="2026-06-30" version="2.0.0.0" md5="3c8ac0ad3e61b2d4bab5900cb3b5fb4b">
-        <package>https://github.com/archicoop/loginOtp/releases/download/v2.0.0/loginOtp-2.0.0.tar.gz</package>
+    <release date="2026-07-30" version="2.0.1.0" md5="6c1f7ed74904362c1422b58e0105e573">
+        <package>https://github.com/archicoop/loginOtp/releases/download/v2.0.1/loginOtp-2.0.1.tar.gz</package>
         <compatibility application="ojs2">
             <version>~3.5.0.0</version>
         </compatibility>
         <certification type="reviewed"/>
-        <description>Major refactor: per-journal configuration, OR-based rule set, plugin always active.</description>
+        <description>Two-factor authentication via email OTP. Configurable per-journal by role.</description>
     </release>
 </plugin>
 </plugins>


### PR DESCRIPTION
Adds version 2.0.1 of the loginOtp plugin (email-based 2FA for OJS 3.5.x)
to the gallery.

This is a major version with a reworked enforcement model: per-journal
configuration, OR-based rule set, plugin always active. See the
[release notes](https://github.com/archicoop/loginOtp/releases/tag/v2.0.1)
and [CHANGELOG](https://github.com/archicoop/loginOtp/blob/v2.0.1/CHANGELOG.md)
for full details.

## Update note

This PR originally proposed v2.0.0, tagged but never publicly distributed
(the PR was still open when v2.0.1 was tagged). It now targets v2.0.1,
which supersedes v2.0.0 with the following changes:

- Fixed `must_change_password` bypass after OTP validation
- Added `[loginOtp] disabled` config flag as emergency-disable safety net
- `LoadHandler` hook now registered with `Hook::SEQUENCE_CORE` priority
- Removed dead `Authentication::authenticate` hook registration and
  helper methods (not present in OJS/OMP 3.5 core)

## Notes

* The previous PR for 1.0.1 was closed without merge, after coordinating
with [@asmecher](https://github.com/asmecher). Skipping the 1.x line on
the gallery — this is the first release we propose for inclusion.
* Compatibility set to `~3.5.0.0` as previously suggested.

cc [@asmecher](https://github.com/asmecher)