### PR TITLE
Open Access Switchboard plugin: OJS 3.5 support and security/privacy improvements on 3.3/3.4

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -11074,6 +11074,27 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="pt_BR">Aprimora a segurança das credenciais da OA Switchboard armazenadas pelo plugin.</description>
 			<description locale="es_ES">Mejora la seguridad de las credenciales de OA Switchboard almacenadas por el plugin.</description>
 		</release>
+		<release date="2026-07-20" version="1.1.3.2" md5="8dd173a9ed131aeca3e50ea00fd05798">
+			<package>https://github.com/lepidus/OASwitchboard/releases/download/v1.1.3.2/OASwitchboard.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.0</version>
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">Improves security and privacy: hardens the P1-PIO delivery flow and removes author emails from the P1-PIO payload.</description>
+			<description locale="pt_BR">Aprimora a segurança e a privacidade: reforça o fluxo de envio P1-PIO e remove os e-mails dos autores do payload P1-PIO.</description>
+			<description locale="es_ES">Mejora la seguridad y la privacidad: refuerza el flujo de envío P1-PIO y elimina los correos electrónicos de los autores del payload P1-PIO.</description>
+		</release>
 		<release date="2025-11-14" version="2.0.2.0" md5="0bff84bf775eb92ea558b5aafda33838">
 			<package>https://github.com/lepidus/OASwitchboard/releases/download/v2.0.2.0/OASwitchboard.tar.gz</package>
 			<compatibility application="ojs2">
@@ -11083,6 +11104,16 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="en">Improves the security of the OA Switchboard credentials stored by the plugin.</description>
 			<description locale="pt_BR">Aprimora a segurança das credenciais da OA Switchboard armazenadas pelo plugin.</description>
 			<description locale="es">Mejora la seguridad de las credenciales de OA Switchboard almacenadas por el plugin.</description>
+		</release>
+		<release date="2026-07-20" version="2.0.2.2" md5="f9ea8c01bc0ca0faee1886e4bdd2edbf">
+			<package>https://github.com/lepidus/OASwitchboard/releases/download/v2.0.2.2/OASwitchboard.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">Improves security and privacy: hardens the P1-PIO delivery flow and removes author emails from the P1-PIO payload.</description>
+			<description locale="pt_BR">Aprimora a segurança e a privacidade: reforça o fluxo de envio P1-PIO e remove os e-mails dos autores do payload P1-PIO.</description>
+			<description locale="es">Mejora la seguridad y la privacidad: refuerza el flujo de envío P1-PIO y elimina los correos electrónicos de los autores del payload P1-PIO.</description>
 		</release>
 		<release date="2026-07-09" version="3.0.1.1" md5="c558dfa0171956a845cde8178a35a997">
 			<package>https://github.com/lepidus/OASwitchboard/releases/download/v3.0.1.1/OASwitchboard.tar.gz</package>

--- a/plugins.xml
+++ b/plugins.xml
@@ -11115,8 +11115,8 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="pt_BR">Aprimora a segurança e a privacidade: reforça o fluxo de envio P1-PIO e remove os e-mails dos autores do payload P1-PIO.</description>
 			<description locale="es">Mejora la seguridad y la privacidad: refuerza el flujo de envío P1-PIO y elimina los correos electrónicos de los autores del payload P1-PIO.</description>
 		</release>
-		<release date="2026-07-09" version="3.0.1.1" md5="c558dfa0171956a845cde8178a35a997">
-			<package>https://github.com/lepidus/OASwitchboard/releases/download/v3.0.1.1/OASwitchboard.tar.gz</package>
+		<release date="2026-07-20" version="3.0.1.3" md5="b09cecda33c56a4d9703296d2c4b021a">
+			<package>https://github.com/lepidus/OASwitchboard/releases/download/v3.0.1.3/OASwitchboard.tar.gz</package>
 			<compatibility application="ojs2">
 				<version>~3.5.0.0</version>
 			</compatibility>

--- a/plugins.xml
+++ b/plugins.xml
@@ -11084,6 +11084,16 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="pt_BR">Aprimora a segurança das credenciais da OA Switchboard armazenadas pelo plugin.</description>
 			<description locale="es">Mejora la seguridad de las credenciales de OA Switchboard almacenadas por el plugin.</description>
 		</release>
+		<release date="2026-07-09" version="3.0.1.1" md5="c558dfa0171956a845cde8178a35a997">
+			<package>https://github.com/lepidus/OASwitchboard/releases/download/v3.0.1.1/OASwitchboard.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This plugin sends a P1 message to the OA Switchboard when a submission is published.</description>
+			<description locale="pt_BR">Esse plugin envia uma mensagem P1 para o OA Switchboard quando uma submissão é publicada.</description>
+			<description locale="es">Este módulo envía un mensaje P1 a la OA Switchboard cuando se publica un envío.</description>
+		</release>
 	</plugin>
 	<plugin category="generic" product="deleteIncompleteSubmissions">
 		<name locale="en">Delete Incomplete Submissions</name>


### PR DESCRIPTION
Releasing [OA Switchboard plugin](https://github.com/lepidus/OASwitchboard) v3, for OJS 3.5

Also updating 3.3 and 3.4 supporting versions with the [latest releases](https://github.com/lepidus/OASwitchboard/releases).