### PR TITLE
Add Reviewer Recommendation Manager plugin 1.0.3.0 for OJS 3.4/3.5

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -12074,4 +12074,28 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="es_ES">Versión inicial para OJS 3.5+</description>
 		</release>
 	</plugin>
+	<plugin category="generic" product="reviewerRecommendationManager">
+		<name locale="en">Reviewer Recommendation Manager</name>
+		<name locale="en_US">Reviewer Recommendation Manager</name>
+		<name locale="pt_BR">Gerenciador de Recomendações do Avaliador</name>
+		<homepage>https://github.com/OJSBR/reviewerRecommendationManager</homepage>
+		<summary locale="en">Rename (multilingual), reorder and disable the reviewer recommendations on OJS 3.4/3.5, preserving the review history.</summary>
+		<summary locale="en_US">Rename (multilingual), reorder and disable the reviewer recommendations on OJS 3.4/3.5, preserving the review history.</summary>
+		<summary locale="pt_BR">Renomear (multilíngue), reordenar e desativar as recomendações do avaliador no OJS 3.4/3.5, preservando o histórico dos pareceres.</summary>
+		<description locale="en"><![CDATA[<p>On OJS 3.4 and 3.5 the six reviewer recommendations (Accept Submission, Revisions Required, Resubmit for Review, Resubmit Elsewhere, Decline Submission, See Comments) are hard-coded. This plugin lets a journal <strong>rename them per language, reorder them and disable the ones it does not use</strong>, without patching OJS core.</p><p>Renaming is done through per-journal gettext override files, so the new wording appears everywhere the label is resolved. Reordering and disabling affect the <em>reviewer form only</em>: editors keep seeing the recommendation recorded on past reviews, so the historical record is never hidden or rewritten. The settings screen always shows the original OJS wording as a fixed reference and warns how many existing reviews already use each option.</p><p><strong>OJS 3.6 note:</strong> PKP has implemented customizable reviewer recommendations in the core for OJS 3.6 (pkp/pkp-lib#1660). This plugin is aimed at journals still running OJS 3.4 or 3.5.</p><p>Ships in 6 languages (English, Portuguese, Spanish, French, Italian and German) and includes a Cypress functional test. No core files are modified.</p>]]></description>
+		<description locale="en_US"><![CDATA[<p>On OJS 3.4 and 3.5 the six reviewer recommendations (Accept Submission, Revisions Required, Resubmit for Review, Resubmit Elsewhere, Decline Submission, See Comments) are hard-coded. This plugin lets a journal <strong>rename them per language, reorder them and disable the ones it does not use</strong>, without patching OJS core.</p><p>Renaming is done through per-journal gettext override files, so the new wording appears everywhere the label is resolved. Reordering and disabling affect the <em>reviewer form only</em>: editors keep seeing the recommendation recorded on past reviews, so the historical record is never hidden or rewritten. The settings screen always shows the original OJS wording as a fixed reference and warns how many existing reviews already use each option.</p><p><strong>OJS 3.6 note:</strong> PKP has implemented customizable reviewer recommendations in the core for OJS 3.6 (pkp/pkp-lib#1660). This plugin is aimed at journals still running OJS 3.4 or 3.5.</p><p>Ships in 6 languages (English, Portuguese, Spanish, French, Italian and German) and includes a Cypress functional test. No core files are modified.</p>]]></description>
+		<maintainer>
+			<name>Eder Sotto</name>
+			<institution>OJSBR</institution>
+			<email>support@ojsbr.com</email>
+		</maintainer>
+		<release date="2026-07-22" version="1.0.3.0" md5="586f015cc30063a462140f8ef109a6db">
+			<package>https://github.com/OJSBR/reviewerRecommendationManager/releases/download/1.0.3.0/reviewerRecommendationManager-1.0.3.0.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<description>Release for OJS 3.4 and 3.5.</description>
+		</release>
+	</plugin>
 </plugins>


### PR DESCRIPTION
Adds a new entry for the **Reviewer Recommendation Manager** plugin. On OJS 3.4/3.5 the six reviewer recommendations are hard-coded; this plugin lets a journal rename them per language, reorder them and disable the ones it does not use, without patching core.

- Repository: https://github.com/OJSBR/reviewerRecommendationManager
- Release: 1.0.3.0
- Package: https://github.com/OJSBR/reviewerRecommendationManager/releases/download/1.0.3.0/reviewerRecommendationManager-1.0.3.0.tar.gz
- Compatibility: OJS `~3.4.0.0` and `~3.5.0.0`
- Licence: GPL-3.0

### Scope, and its relationship with OJS 3.6

I am aware that customizable reviewer recommendations were implemented in core for **OJS 3.6** (pkp/pkp-lib#1660). This entry is therefore scoped to **3.4 and 3.5 only**, for journals that are still on those lines, and the limitation is stated explicitly in the plugin description and README so nobody installs it expecting it to be needed on 3.6. If you would rather not list a plugin that core supersedes in the next release, I completely understand - feel free to close this.

### How it works

- **Renaming** is done with per-journal gettext override files registered through the Locale facade, so the new wording resolves everywhere the label is used.
- **Reordering / disabling** only touches the `reviewerRecommendationOptions` template variable on the reviewer form (`reviewer/review/step3.tpl`) before it renders. The editor view is untouched, so recommendations recorded on past reviews are never hidden or rewritten.
- The settings screen always shows the original OJS wording as a fixed reference, and warns how many existing reviews already use each option.

### Notes

- Package is a single `reviewerRecommendationManager/` directory with `LICENSE` at its root; CI files are excluded via `.gitattributes` and there are no composer/npm dependencies.
- Validated locally with `xmllint --schema ./plugins.xsd ./plugins.xml --noout`; the package URL resolves and its MD5 matches.
- Ships in 6 languages (en, pt_BR, es, fr_FR, it, de) and includes a Cypress functional test covering the settings round-trip.
- No `certification` element included - that is for the maintainers to decide.

Maintained by OJSBR (https://ojsbr.com).