### PR TITLE
Add WoS Reviewer Locator plugin version 1.3.5.3

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -7745,6 +7745,14 @@
 			<certification type="reviewed"/>
 			<description>Web of Science Reviewer Locator plugin for OJS 3.5</description>
 		</release>
+		<release date="2026-06-29" version="1.3.5.3" md5="f98a9ab7b7b2f951220803fcae2fd1be">
+			<package>https://github.com/clarivate/wos_reviewer_locator_plugin_ojs/releases/download/v1.3.5.3/wosReviewerLocator_1_3_5_3.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description>Web of Science Reviewer Locator plugin for OJS 3.5</description>
+		</release>
 	</plugin>
 	<plugin category="themes" product="pragma">
 		<name locale="en">Pragma</name>


### PR DESCRIPTION
Add the most recent version of the plugin to the gallery. This version fixes issues with plugin availability for certain user roles.