### PR TITLE
Adds new releases of SciELO Submissions Report

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -9113,6 +9113,39 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="es_ES">Esta versión corrige un problema con usuarios deshabilitados, que afectaba las columnas de editores en el informe.</description>
 			<description locale="pt_BR">Esta versão corrige um problema com usuários desativados, que afetava as colunas de editores no relatório.</description>
 		</release>
+		<release date="2026-07-31" version="2.4.6.2" md5="e57417953a91a977b596ad94b312ef03">
+			<package>https://github.com/lepidus/scieloSubmissionsReport/releases/download/v2.4.6.2/scieloSubmissionsReport.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>3.3.0.1</version>
+				<version>3.3.0.2</version>
+				<version>3.3.0.3</version>
+				<version>3.3.0.4</version>
+				<version>3.3.0.5</version>
+				<version>3.3.0.6</version>
+				<version>3.3.0.7</version>
+				<version>3.3.0.8</version>
+				<version>3.3.0.9</version>
+				<version>3.3.0.10</version>
+				<version>~3.3.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en_US">This release fixes a minor error which affected retrieving of section titles.</description>
+			<description locale="es_ES">Esta versión corrige un error menor que afectaba a la recuperación de los títulos de las secciones.</description>
+			<description locale="pt_BR">This release fixes a minor error which affected retrieving of section titles</description>
+		</release>
 		<release date="2024-11-06" version="3.0.2.1" md5="267623738b12e249beec161a43722c3d">
 			<package>https://github.com/lepidus/scieloSubmissionsReport/releases/download/v3.0.2.1/scieloSubmissionsReport.tar.gz</package>
 			<compatibility application="ojs2">
@@ -9151,6 +9184,32 @@ the registration of DOIs with mEDRA.</p>]]></description>
 			<description locale="en">This release fixes a problem with disabled users, which affected the editors columns in the report.</description>
 			<description locale="es">Esta versión corrige un problema con usuarios deshabilitados, que afectaba las columnas de editores en el informe.</description>
 			<description locale="pt_BR">Esta versão corrige um problema com usuários desativados, que afetava as colunas de editores no relatório.</description>
+		</release>
+		<release date="2026-07-31" version="3.0.6.1" md5="32ba86cf1708910b13debd1d8719e1dd">
+			<package>https://github.com/lepidus/scieloSubmissionsReport/releases/download/v3.0.6.1/scieloSubmissionsReport.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>~3.4.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This release fixes a minor error which affected retrieving of section titles.</description>
+			<description locale="es">Esta versión corrige un error menor que afectaba a la recuperación de los títulos de las secciones.</description>
+			<description locale="pt_BR">This release fixes a minor error which affected retrieving of section titles</description>
+		</release>
+		<release date="2026-07-31" version="4.0.1.1" md5="08a91acf7b7766e602255755919536e1">
+			<package>https://github.com/lepidus/scieloSubmissionsReport/releases/download/v4.0.1.1/scieloSubmissionsReport.tar.gz</package>
+			<compatibility application="ojs2">
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<compatibility application="ops">
+				<version>~3.5.0.0</version>
+			</compatibility>
+			<certification type="reviewed"/>
+			<description locale="en">This release fixes a minor error which affected retrieving of section titles.</description>
+			<description locale="es">Esta versión corrige un error menor que afectaba a la recuperación de los títulos de las secciones.</description>
+			<description locale="pt_BR">This release fixes a minor error which affected retrieving of section titles</description>
 		</release>
 	</plugin>
 	<plugin category="generic" product="epubViewer">


### PR DESCRIPTION
Releases added:
 - [4.0.1.1](https://github.com/lepidus/scieloSubmissionsReport/releases/tag/v4.0.1.1)
 - [3.0.6.1](https://github.com/lepidus/scieloSubmissionsReport/releases/tag/v4.0.1.1)
 - [2.4.6.2](https://github.com/lepidus/scieloSubmissionsReport/releases/tag/v2.4.6.2)